### PR TITLE
Client refactor

### DIFF
--- a/bloop/__init__.py
+++ b/bloop/__init__.py
@@ -1,3 +1,4 @@
+from bloop.client import Client
 from bloop.column import Column
 from bloop.condition import Condition
 from bloop.engine import Engine
@@ -12,10 +13,10 @@ from bloop.types import (
 from bloop.model import new_base
 
 __all__ = [
-    "Boolean", "Binary", "Column", "Condition", "ConstraintViolation",
-    "DateTime", "Engine", "Float", "GlobalSecondaryIndex", "Integer",
-    "List", "LocalSecondaryIndex", "Map", "NotModified", "Set",
-    "String", "TableMismatch", "TypedMap", "UnboundModel", "UUID",
-    "new_base", "engine_for_profile"
+    "Boolean", "Binary", "Client", "Column", "Condition",
+    "ConstraintViolation", "DateTime", "Engine", "Float",
+    "GlobalSecondaryIndex", "Integer", "List", "LocalSecondaryIndex",
+    "Map", "NotModified", "Set", "String", "TableMismatch", "TypedMap",
+    "UnboundModel", "UUID", "new_base", "engine_for_profile"
 ]
 __version__ = "0.9.10"

--- a/bloop/__init__.py
+++ b/bloop/__init__.py
@@ -19,4 +19,4 @@ __all__ = [
     "Map", "NotModified", "Set", "String", "TableMismatch", "TypedMap",
     "UnboundModel", "UUID", "new_base", "engine_for_profile"
 ]
-__version__ = "0.9.10"
+__version__ = "0.9.11"

--- a/bloop/client.py
+++ b/bloop/client.py
@@ -83,7 +83,7 @@ class Client(object):
     .. _DynamoDB API Reference:
         http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Operations.html
     """
-    def __init__(self, session=None, backoff_func=None,
+    def __init__(self, boto_client=None, backoff_func=None,
                  batch_size=MAX_BATCH_SIZE):
         """
         backoff_func is an optional function that takes an int
@@ -92,7 +92,7 @@ class Client(object):
             - raise to stop
         """
         # Fall back to the global session
-        self.boto_client = (session or boto3).client("dynamodb")
+        self.boto_client = boto_client or boto3.client("dynamodb")
         self.backoff_func = backoff_func or _default_backoff_func
         self.batch_size = batch_size
 

--- a/bloop/client.py
+++ b/bloop/client.py
@@ -70,7 +70,8 @@ class Client(object):
         * `DynamoDB API Reference`_
 
     Attributes:
-        client (boto3.client): Low-level client to communicate with DynamoDB
+        boto_client (boto3.client): Low-level client to communicate
+            with DynamoDB
         backoff_func (func<int>): Calculates the duration to wait between
             retries.  By default, an exponential backoff function is used.
         batch_size (int): The maximum number of items to include in a batch
@@ -91,7 +92,7 @@ class Client(object):
             - raise to stop
         """
         # Fall back to the global session
-        self.client = (session or boto3).client("dynamodb")
+        self.boto_client = (session or boto3).client("dynamodb")
         self.backoff_func = backoff_func or _default_backoff_func
         self.batch_size = batch_size
 
@@ -175,7 +176,7 @@ class Client(object):
         """
         response = {}
         get_batch = functools.partial(self._call_with_retries,
-                                      self.client.batch_get_item)
+                                      self.boto_client.batch_get_item)
         request_batches = _partition_batch_get_input(self.batch_size, items)
 
         for request_batch in request_batches:
@@ -223,7 +224,7 @@ class Client(object):
             raise bloop.exceptions.AbstractModelException(model)
         table = _table_for_model(model)
         create = functools.partial(self._call_with_retries,
-                                   self.client.create_table)
+                                   self.boto_client.create_table)
         try:
             create(**table)
         except botocore.exceptions.ClientError as error:
@@ -254,7 +255,7 @@ class Client(object):
         .. _delete_item (DynamoDB Client):
             https://boto3.readthedocs.org/en/latest/reference/services/dynamodb.html#DynamoDB.Client.delete_item
         """
-        self._modify_item(self.client.delete_item, "delete", item)
+        self._modify_item(self.boto_client.delete_item, "delete", item)
 
     def describe_table(self, model):
         """Load the schema for a model's table, stripping out useless metadata.
@@ -293,7 +294,7 @@ class Client(object):
 
         """
         description = self._call_with_retries(
-            self.client.describe_table,
+            self.boto_client.describe_table,
             TableName=model.Meta.table_name)["Table"]
 
         # We don't care about a bunch of the returned attributes, and want to
@@ -322,10 +323,10 @@ class Client(object):
         return table
 
     def query(self, request):
-        return self._filter(self.client.query, request)
+        return self._filter(self.boto_client.query, request)
 
     def scan(self, request):
-        return self._filter(self.client.scan, request)
+        return self._filter(self.boto_client.scan, request)
 
     def update_item(self, item):
         """Update an item in DynamoDB.  Only modify given values.
@@ -349,7 +350,7 @@ class Client(object):
         .. _update_item (DynamoDB Client):
             https://boto3.readthedocs.org/en/latest/reference/services/dynamodb.html#DynamoDB.Client.update_item
         """
-        self._modify_item(self.client.update_item, "update", item)
+        self._modify_item(self.boto_client.update_item, "update", item)
 
     def validate_table(self, model):
         """Busy poll until table is ACTIVE.  Raises on schema mismatch.

--- a/bloop/engine.py
+++ b/bloop/engine.py
@@ -16,8 +16,7 @@ _DEFAULT_CONFIG = {
     "atomic": False,
     "consistent": False,
     "prefetch": 0,
-    "strict": True,
-    "session": None
+    "strict": True
 }
 
 
@@ -131,10 +130,12 @@ class _LoadManager:
 class Engine:
     client = None
 
-    def __init__(self, **config):
+    def __init__(self, client=None, **config):
         # Unique namespace so the type engine for multiple bloop Engines
         # won't have the same TypeDefinitions
         self.type_engine = declare.TypeEngine.unique()
+
+        self.client = client
         self.config = dict(_DEFAULT_CONFIG)
         self.config.update(config)
 
@@ -177,8 +178,9 @@ class Engine:
 
     def bind(self, *, base):
         """Create tables for all models subclassing base"""
-        self.client = self.client or bloop.client.Client(
-            session=self.config["session"])
+        # If not manually configured, use a default bloop.Client
+        # with the default boto3.client("dynamodb")
+        self.client = self.client or bloop.client.Client()
 
         # Make sure we're looking at models
         if not isinstance(base, bloop.model.ModelMetaclass):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,11 +36,11 @@ Query or scan by column values::
     email = 'foo@bar.com'
     yesterday = arrow.now().replace(days=-1)
 
-    acount = engine.query(Account.by_email)\
+    account = engine.query(Account.by_email)\
                    .key(Account.email == email)\
                    .first()
     tweets = engine.query(Tweet)\
-                   .key(Tweet.acount == acount.id)
+                   .key(Tweet.account == account.id)
 
     for tweet in tweets.filter(Tweet.date >= yesterday):
         print(tweet.content)
@@ -55,6 +55,7 @@ Query or scan by column values::
     user/models
     user/engine
     user/types
+    user/patterns
     user/advanced
     dev/contributing
     dev/internals

--- a/docs/user/engine.rst
+++ b/docs/user/engine.rst
@@ -54,20 +54,22 @@ bound.
 client
 ------
 
-By default bloop will let boto determine what credentials should be used.  When
-you want to use a named profile, or connect to a different region, you can
-provide a `boto3 session`_ to the engine at initialization::
+By default bloop will let boto3 determine what credentials should be used.
+When you want to use a named profile, or connect to a different region, you can
+build a custom boto3 client, and wrap it in the bloop Client::
 
     import boto3
     import bloop
 
-    session = boto3.session.Session(profile_name='not-default-profile')
-    engine = bloop.Engine(session=session)
+    # Customize your connection here
+    boto_client = boto3.client(...)
 
-You should never need to interact with the engine's client directly; the
-interface exposed does not translate 1:1 to the boto3 client interface.
+    # Wrap the boto3 client and inject into the engine
+    bloop_client = bloop.Client(boto_client=boto_client)
+    engine = bloop.Engine(client=bloop_client)
 
-.. _boto3 session: http://boto3.readthedocs.org/en/latest/reference/core/session.html
+Generally, you should only need to interact with bloop's client layer when
+using a custom boto3 client.
 
 .. _config:
 

--- a/docs/user/patterns.rst
+++ b/docs/user/patterns.rst
@@ -1,0 +1,36 @@
+Patterns and Examples
+=====================
+
+Connecting to DynamoDB Local
+----------------------------
+
+::
+
+    import boto3
+    import bloop
+
+    boto_client = boto3.client("dynamodb", endpoint="http://127.0.0.1:8000")
+    client = bloop.Client(boto_client=boto_client)
+    engine = bloop.Engine(client=client)
+
+    ...
+
+
+Generic "if not exist" condition
+--------------------------------
+
+::
+
+    def if_not_exist(obj):
+        hash_key = obj.Meta.hash_key
+        range_key = obj.Meta.range_key
+
+        condition = hash_key.is_(None)
+        if range_key:
+            condition &= range_key.is_(None)
+        return condition
+
+
+    # Usage
+    tweet = Tweet(account=uuid.uuid4(), id="numberoverzero", ...)
+    engine.save(tweet, condition=if_not_exist(tweet))

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(HERE, "README.rst")) as f:
 
 
 def get_version():
-    with open("bloop/__init__.py") as f:
+    with open(os.path.join(HERE, "bloop/__init__.py")) as f:
         for line in f:
             if line.startswith("__version__"):
                 return eval(line.split("=")[-1])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,6 @@ import bloop
 import bloop.client
 import bloop.exceptions
 import bloop.util
-import boto3
 import botocore
 import copy
 import pytest
@@ -14,8 +13,10 @@ from test_models import SimpleModel, ComplexModel, User
 
 @pytest.fixture
 def client():
-    session = Mock(spec=boto3.session.Session)
-    return bloop.client.Client(session=session)
+    # No spec since clients are generated dynamically.
+    # We could use botocore.client.BaseClient but it's so generic
+    # that we don't gain any useful inspections
+    return bloop.client.Client(boto_client=Mock())
 
 
 def client_error(code):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -44,11 +44,11 @@ def test_batch_get_one_item(client):
     def handle(RequestItems):
         assert RequestItems == expected_request
         return response
-    client.client.batch_get_item.side_effect = handle
+    client.boto_client.batch_get_item.side_effect = handle
 
     response = client.batch_get_items(request)
     assert response == expected_response
-    client.client.batch_get_item.assert_called_once_with(
+    client.boto_client.batch_get_item.assert_called_once_with(
         RequestItems=expected_request)
 
 
@@ -79,7 +79,7 @@ def test_batch_get_one_batch(client):
     def handle(RequestItems):
         assert RequestItems == expected_request
         return response
-    client.client.batch_get_item = handle
+    client.boto_client.batch_get_item = handle
 
     response = client.batch_get_items(request)
     assert response == expected_response
@@ -122,7 +122,7 @@ def test_batch_get_paginated(client):
         calls += 1
         assert RequestItems == expected
         return response
-    client.client.batch_get_item = handle
+    client.boto_client.batch_get_item = handle
 
     response = client.batch_get_items(request)
 
@@ -159,7 +159,7 @@ def test_batch_get_unprocessed(client):
         calls += 1
         assert RequestItems == expected
         return response
-    client.client.batch_get_item = handle
+    client.boto_client.batch_get_item = handle
 
     response = client.batch_get_items(request)
 
@@ -268,9 +268,9 @@ def test_create_table(client):
 
     def create_table(**table):
         assert bloop.util.ordered(table) == bloop.util.ordered(expected)
-    client.client.create_table.side_effect = create_table
+    client.boto_client.create_table.side_effect = create_table
     client.create_table(ComplexModel)
-    assert client.client.create_table.call_count == 1
+    assert client.boto_client.create_table.call_count == 1
 
 
 def test_create_subclass(client):
@@ -291,18 +291,18 @@ def test_create_subclass(client):
     def create_table(**table):
         assert bloop.util.ordered(table) == bloop.util.ordered(expected)
 
-    client.client.create_table.side_effect = create_table
+    client.boto_client.create_table.side_effect = create_table
     client.create_table(SubModel)
-    assert client.client.create_table.call_count == 1
+    assert client.boto_client.create_table.call_count == 1
 
 
 def test_create_raises_unknown(client):
-    client.client.create_table.side_effect = client_error("FooError")
+    client.boto_client.create_table.side_effect = client_error("FooError")
 
     with pytest.raises(botocore.exceptions.ClientError) as excinfo:
         client.create_table(User)
     assert excinfo.value.response["Error"]["Code"] == "FooError"
-    assert client.client.create_table.call_count == 1
+    assert client.boto_client.create_table.call_count == 1
 
 
 def test_create_abstract_raises(client):
@@ -313,65 +313,65 @@ def test_create_abstract_raises(client):
 
 
 def test_create_already_exists(client):
-    client.client.create_table.side_effect = \
+    client.boto_client.create_table.side_effect = \
         client_error("ResourceInUseException")
 
     client.create_table(User)
-    assert client.client.create_table.call_count == 1
+    assert client.boto_client.create_table.call_count == 1
 
 
 def test_delete_item(client):
     request = {"foo": "bar"}
     client.delete_item(request)
-    client.client.delete_item.assert_called_once_with(**request)
+    client.boto_client.delete_item.assert_called_once_with(**request)
 
 
 def test_delete_item_unknown_error(client):
     request = {"foo": "bar"}
-    client.client.delete_item.side_effect = client_error("FooError")
+    client.boto_client.delete_item.side_effect = client_error("FooError")
 
     with pytest.raises(botocore.exceptions.ClientError) as excinfo:
         client.delete_item(request)
     assert excinfo.value.response["Error"]["Code"] == "FooError"
-    client.client.delete_item.assert_called_once_with(**request)
+    client.boto_client.delete_item.assert_called_once_with(**request)
 
 
 def test_delete_item_condition_failed(client):
     request = {"foo": "bar"}
-    client.client.delete_item.side_effect = \
+    client.boto_client.delete_item.side_effect = \
         client_error("ConditionalCheckFailedException")
 
     with pytest.raises(bloop.exceptions.ConstraintViolation) as excinfo:
         client.delete_item(request)
     assert excinfo.value.obj == request
-    client.client.delete_item.assert_called_once_with(**request)
+    client.boto_client.delete_item.assert_called_once_with(**request)
 
 
 def test_update_item(client):
     request = {"foo": "bar"}
     client.update_item(request)
-    client.client.update_item.assert_called_once_with(**request)
+    client.boto_client.update_item.assert_called_once_with(**request)
 
 
 def test_update_item_unknown_error(client):
     request = {"foo": "bar"}
-    client.client.update_item.side_effect = client_error("FooError")
+    client.boto_client.update_item.side_effect = client_error("FooError")
 
     with pytest.raises(botocore.exceptions.ClientError) as excinfo:
         client.update_item(request)
     assert excinfo.value.response["Error"]["Code"] == "FooError"
-    client.client.update_item.assert_called_once_with(**request)
+    client.boto_client.update_item.assert_called_once_with(**request)
 
 
 def test_update_item_condition_failed(client):
     request = {"foo": "bar"}
-    client.client.update_item.side_effect = \
+    client.boto_client.update_item.side_effect = \
         client_error("ConditionalCheckFailedException")
 
     with pytest.raises(bloop.exceptions.ConstraintViolation) as excinfo:
         client.update_item(request)
     assert excinfo.value.obj == request
-    client.client.update_item.assert_called_once_with(**request)
+    client.boto_client.update_item.assert_called_once_with(**request)
 
 
 def test_describe_table(client):
@@ -420,10 +420,10 @@ def test_describe_table(client):
     lsi.pop("ItemCount")
     lsi.pop("IndexSizeBytes")
 
-    client.client.describe_table.return_value = {"Table": full}
+    client.boto_client.describe_table.return_value = {"Table": full}
 
     assert client.describe_table(ComplexModel) == expected
-    client.client.describe_table.assert_called_once_with(
+    client.boto_client.describe_table.assert_called_once_with(
         TableName=ComplexModel.Meta.table_name)
 
 
@@ -434,8 +434,8 @@ def test_describe_table(client):
     ({"Count": 1, "ScannedCount": 2}, (1, 2))
 ], ids=str)
 def test_query_scan(client, response, expected):
-    client.client.query.return_value = response
-    client.client.scan.return_value = response
+    client.boto_client.query.return_value = response
+    client.boto_client.scan.return_value = response
 
     expected = {"Count": expected[0], "ScannedCount": expected[1]}
     assert client.query({}) == expected
@@ -464,9 +464,9 @@ def test_validate_compares_tables(client):
              "Projection": {"ProjectionType": "ALL"}}],
         "TableName": "User"}
 
-    client.client.describe_table.return_value = {"Table": full}
+    client.boto_client.describe_table.return_value = {"Table": full}
     client.validate_table(User)
-    client.client.describe_table.assert_called_once_with(TableName="User")
+    client.boto_client.describe_table.assert_called_once_with(TableName="User")
 
 
 def test_validate_checks_status(client):
@@ -474,19 +474,19 @@ def test_validate_checks_status(client):
     # based on busy tables or indexes
     full = bloop.client._table_for_model(User)
 
-    client.client.describe_table.side_effect = [
+    client.boto_client.describe_table.side_effect = [
         {"Table": {"TableStatus": "CREATING"}},
         {"Table": {"GlobalSecondaryIndexes": [{"IndexStatus": "CREATING"}]}},
         {"Table": full}
     ]
     client.validate_table(User)
-    client.client.describe_table.assert_called_with(TableName="User")
-    assert client.client.describe_table.call_count == 3
+    client.boto_client.describe_table.assert_called_with(TableName="User")
+    assert client.boto_client.describe_table.call_count == 3
 
 
 def test_validate_fails(client):
     """dynamo returns a json document that doesn't match the expected table"""
-    client.client.describe_table.return_value = {"Table": {}}
+    client.boto_client.describe_table.return_value = {"Table": {}}
     with pytest.raises(bloop.exceptions.TableMismatch) as excinfo:
         client.validate_table(ComplexModel)
 
@@ -508,6 +508,7 @@ def test_validate_simple_model(client):
         "TableName": "Simple",
         "ProvisionedThroughput": {"ReadCapacityUnits": 1,
                                   "WriteCapacityUnits": 1}}
-    client.client.describe_table.return_value = {"Table": full}
+    client.boto_client.describe_table.return_value = {"Table": full}
     client.validate_table(SimpleModel)
-    client.client.describe_table.assert_called_once_with(TableName="Simple")
+    client.boto_client.describe_table.assert_called_once_with(
+        TableName="Simple")


### PR DESCRIPTION
`bloop.Engine` takes a `bloop.Client` instead of a `boto3.session.Session`, which assumed a certain model for building a bloop client.

Added sample to a new section, `docs/user/patterns.rst`