### PR TITLE
Filter attributes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,12 +90,15 @@ Query or scan by column values:
     email = 'foo@bar.com'
     yesterday = arrow.now().replace(days=-1)
 
-    account = engine.query(Account.by_email)\
-                   .key(Account.email == email).first()
-    tweets = engine.query(Tweet)\
-                   .key(Tweet.account == account.id)
+    acct_query = engine.query(Account.by_email)
+    acct_query.key = Account.email == email
+    account = acct_query.first()
 
-    for tweet in tweets.filter(Tweet.date >= yesterday):
+    tweet_query = engine.query(Tweet)
+    tweet_query.key = Tweet.account == account.id
+    tweet_query.filter = Tweet.date >= yesterday
+
+    for tweet in tweet_query.build():
         print(tweet.content)
 
 

--- a/tests/helpers/models.py
+++ b/tests/helpers/models.py
@@ -80,6 +80,18 @@ class VectorModel(BaseModel):
     }))
 
 
+# Provides a gsi and lsi with constrained projections for testing Filter.select validation
+class ProjectedIndexes(BaseModel):
+    h = Column(Integer, hash_key=True)
+    r = Column(Integer, range_key=True)
+    both = Column(String)
+    neither = Column(String)
+    gsi_only = Column(String)
+    lsi_only = Column(String)
+
+    by_gsi = GlobalSecondaryIndex(hash_key="h", projection=["both", "gsi_only"])
+    by_lsi = LocalSecondaryIndex(range_key="r", projection=["both", "lsi_only"])
+
 conditions = set()
 
 


### PR DESCRIPTION
Closes #54

This drops the ability to chain calls for simply setting attributes.  This is more pythonic, and has the added benefit of centralizing the query/scan validation to `build`.