### PR TITLE
Strict, projection refactor

### DIFF
--- a/bloop/engine.py
+++ b/bloop/engine.py
@@ -204,7 +204,7 @@ class Engine:
                     not_loaded.update(index_set)
             raise MissingObjects("Failed to load some objects.", objects=not_loaded)
 
-    def query(self, model_or_index, key=None, filter=None, projection="all", limit=None, strict=True,
+    def query(self, model_or_index, key=None, filter=None, projection="all", limit=None,
               consistent=False, forward=True, **kwargs):
         if isinstance(model_or_index, Index):
             model, index = model_or_index.model, model_or_index
@@ -213,7 +213,7 @@ class Engine:
         validate_not_abstract(model)
         q = Query(
             engine=self, session=self.session, model=model, index=index, key=key, filter=filter,
-            projection=projection, limit=limit, strict=strict, consistent=consistent, forward=forward)
+            projection=projection, limit=limit, consistent=consistent, forward=forward)
         return iter(q.prepare())
 
     def save(self, *objs, condition=None, atomic=False):
@@ -229,7 +229,7 @@ class Engine:
             self.session.save_item(item)
             object_saved.send(self, obj=obj)
 
-    def scan(self, model_or_index, filter=None, projection="all", limit=None, strict=True, consistent=False, **kwargs):
+    def scan(self, model_or_index, filter=None, projection="all", limit=None, consistent=False, **kwargs):
         if isinstance(model_or_index, Index):
             model, index = model_or_index.model, model_or_index
         else:
@@ -237,5 +237,5 @@ class Engine:
         validate_not_abstract(model)
         s = Scan(
             engine=self, session=self.session, model=model, index=index, filter=filter,
-            projection=projection, limit=limit, strict=strict, consistent=consistent)
+            projection=projection, limit=limit, consistent=consistent)
         return iter(s.prepare())

--- a/bloop/models.py
+++ b/bloop/models.py
@@ -21,14 +21,6 @@ model_created = signal("model_created")
 object_modified = signal("object_modified")
 
 
-def available_columns_for(model, index, strict):
-    if not index or (not strict and isinstance(index, LocalSecondaryIndex)):
-        return model.Meta.columns
-    # GSI or strict LSI
-    else:
-        return index.projected_columns
-
-
 def loaded_columns(obj):
     """Yields each (model_name, value) tuple for all columns in an object that aren't missing"""
     for column in sorted(obj.Meta.columns, key=lambda c: c.model_name):
@@ -38,22 +30,31 @@ def loaded_columns(obj):
 
 
 def validate_projection(projection):
-    # String check first since it is also an Iterable
+    validated_projection = {
+        "mode": None,
+        "included": None,
+        "available": None,
+        "strict": True
+    }
+
+    # String check first since it is also an Iterable.
+    # Without this, the following will make "unknown" a list
     if isinstance(projection, str):
         if projection not in ("keys", "all"):
             raise InvalidIndex("{!r} is not a valid Index projection.".format(projection))
-        projection, projected_columns = projection, None
+        validated_projection["mode"] = projection
     elif isinstance(projection, collections.abc.Iterable):
         projection = list(projection)
         all_names = all(isinstance(item, str) for item in projection)
         if not all_names:
             raise InvalidIndex(
                 "Index projection must be a list of strings when selecting specific Columns.")
-        projection, projected_columns = "include", projection
+        validated_projection["mode"] = "include"
+        validated_projection["included"] = projection
     else:
         raise InvalidIndex(
             "Index projection must be 'all', 'keys', or a list of Column names.")
-    return projection, projected_columns
+    return validated_projection
 
 
 class ModelMetaclass(declare.ModelMetaclass):
@@ -127,6 +128,16 @@ def setup_columns(meta):
     for column in meta.columns:
         column.model = meta.model
 
+    # API consistency with an Index, so (index or model.Meta) can be
+    # used interchangeably to get the available columns from that
+    # object.
+    meta.projection = {
+        "mode": "all",
+        "included": meta.columns,
+        "available": meta.columns,
+        "strict": True
+    }
+
 
 def setup_indexes(meta):
     """Filter indexes from fields, compute projection for each index"""
@@ -197,8 +208,7 @@ class Index(declare.Field):
         self._dynamo_name = name
         super().__init__(**kwargs)
 
-        # projected_columns will be set up in `_bind`
-        self.projection, self.projected_columns = validate_projection(projection)
+        self.projection = validate_projection(projection)
 
     def __repr__(self):
         if isinstance(self, LocalSecondaryIndex):
@@ -214,7 +224,7 @@ class Index(declare.Field):
         return "<{}[{}.{}={}]>".format(
             cls_name,
             self.model.__name__, self.model_name,
-            self.projection
+            self.projection["mode"]
         )
 
     @property
@@ -239,15 +249,20 @@ class Index(declare.Field):
 
         # Compute and the projected columns
         # All projections include model + index keys
-        projected = set.union(model.Meta.keys, self.keys)
+        projection_keys = set.union(model.Meta.keys, self.keys)
 
-        # nothing to do when projection is "keys"
-        if self.projection == "all":
-            projected.update(model.Meta.columns)
-        if self.projection == "include":
-            projected.update(columns[name] for name in self.projected_columns)
-
-        self.projected_columns = projected
+        if self.projection["mode"] == "keys":
+            self.projection["included"] = self.projection["available"] = projection_keys
+        elif self.projection["mode"] == "all":
+            self.projection["included"] = self.projection["available"] = model.Meta.columns
+        elif self.projection["mode"] == "include":  # pragma: no branch
+            projection = set(columns[name] for name in self.projection["included"])
+            projection.update(projection_keys)
+            self.projection["included"] = projection
+            if self.projection["strict"]:
+                self.projection["available"] = projection
+            else:
+                self.projection["available"] = model.Meta.columns
 
     # TODO: disallow set/get/del for an index; these don't store values.  Raise AttributeError.
 
@@ -261,13 +276,14 @@ class GlobalSecondaryIndex(Index):
 
 class LocalSecondaryIndex(Index):
     """ LSIs don't have individual read/write units """
-    def __init__(self, *, projection, range_key, name=None, **kwargs):
+    def __init__(self, *, projection, range_key, name=None, strict=True, **kwargs):
         # Hash key MUST be the table hash; do not specify
         if "hash_key" in kwargs:
             raise InvalidIndex("An LSI shares its hash key with the Model.")
         if ("write_units" in kwargs) or ("read_units" in kwargs):
             raise InvalidIndex("An LSI shares its provisioned throughput with the Model.")
         super().__init__(range_key=range_key, name=name, projection=projection, **kwargs)
+        self.projection["strict"] = strict
 
     def _bind(self, model):
         """Raise if the model doesn't have a range key"""

--- a/bloop/models.py
+++ b/bloop/models.py
@@ -252,17 +252,20 @@ class Index(declare.Field):
         projection_keys = set.union(model.Meta.keys, self.keys)
 
         if self.projection["mode"] == "keys":
-            self.projection["included"] = self.projection["available"] = projection_keys
+            self.projection["included"] = projection_keys
         elif self.projection["mode"] == "all":
-            self.projection["included"] = self.projection["available"] = model.Meta.columns
+            self.projection["included"] = model.Meta.columns
         elif self.projection["mode"] == "include":  # pragma: no branch
             projection = set(columns[name] for name in self.projection["included"])
             projection.update(projection_keys)
             self.projection["included"] = projection
-            if self.projection["strict"]:
-                self.projection["available"] = projection
-            else:
-                self.projection["available"] = model.Meta.columns
+
+        # Strict has the same availability as the included columns,
+        # while non-strict has access to the full range of columns
+        if self.projection["strict"]:
+            self.projection["available"] = self.projection["included"]
+        else:
+            self.projection["available"] = model.Meta.columns
 
     # TODO: disallow set/get/del for an index; these don't store values.  Raise AttributeError.
 

--- a/bloop/search.py
+++ b/bloop/search.py
@@ -46,7 +46,7 @@ def validate_key_condition(model, index, key):
     # Model will always be provided, but Index has priority
     query_on = index or model.Meta
 
-    # `Model_or_Index.hash_key == value`
+    # (model or index).hash_key == value
     # Valid for both (hash,) and (hash, range)
     if check_hash_key(query_on, key):
         return

--- a/bloop/search.py
+++ b/bloop/search.py
@@ -11,7 +11,7 @@ from .exceptions import (
     UnknownSearchMode,
 )
 from .expressions import render
-from .models import Column, GlobalSecondaryIndex, available_columns_for
+from .models import Column, GlobalSecondaryIndex
 from .util import (
     printable_column_name,
     printable_query,
@@ -78,16 +78,14 @@ def validate_key_condition(model, index, key):
     fail_bad_range(query_on)
 
 
-def validate_search_projection(model, index, strict, projection):
+def validate_search_projection(model, index, projection):
     if not projection:
         raise InvalidProjection("The projection must be 'count', 'all', or a list of Columns to include.")
     if projection == "count":
         return None
 
-    available_columns = available_columns_for(model, index, strict)
-
     if projection == "all":
-        return available_columns
+        return (index or model.Meta).projection["included"]
 
     # Keep original around for error messages
     original_projection = projection
@@ -111,8 +109,8 @@ def validate_search_projection(model, index, strict, projection):
         raise InvalidProjection(
             "{!r} is not valid: it must be only Columns or only their model names.".format(original_projection))
 
-    # Must be subset of the available columns
-    if set(projection) <= available_columns:
+    # Can the full available columns support this projection?
+    if set(projection) <= (index or model.Meta).projection["available"]:
         return projection
 
     raise InvalidProjection(
@@ -168,7 +166,7 @@ class Search:
 
     def __init__(
             self, engine=None, session=None, model=None, index=None, key=None, filter=None,
-            projection=None, limit=None, strict=True, consistent=False, forward=True):
+            projection=None, limit=None, consistent=False, forward=True):
         self.engine = engine
         self.session = session
         self.model = model
@@ -177,7 +175,6 @@ class Search:
         self.filter = filter
         self.projection = projection
         self.limit = limit
-        self.strict = strict
         self.consistent = consistent
         self.forward = forward
 
@@ -196,7 +193,6 @@ class Search:
             filter=self.filter,
             projection=self.projection,
             limit=self.limit,
-            strict=self.strict,
             consistent=self.consistent,
             forward=self.forward
         )
@@ -224,8 +220,6 @@ class PreparedSearch:
 
         self.key = None
 
-        self.strict = None
-        self._available_columns = None
         self._projected_columns = None
         self._projection_mode = None
 
@@ -238,12 +232,12 @@ class PreparedSearch:
 
     def prepare(
             self, engine=None, mode=None, session=None, model=None, index=None, key=None,
-            filter=None, projection=None, limit=None, strict=None, consistent=None, forward=None):
+            filter=None, projection=None, limit=None, consistent=None, forward=None):
 
         self.prepare_session(engine, session, mode)
         self.prepare_model(model, index, consistent)
         self.prepare_key(key)
-        self.prepare_projection(projection, strict)
+        self.prepare_projection(projection)
         self.prepare_filter(filter)
         self.prepare_constraints(limit, forward)
 
@@ -267,10 +261,8 @@ class PreparedSearch:
         self.key = key
         validate_key_condition(self.model, self.index, self.key)
 
-    def prepare_projection(self, projection, strict):
-        self.strict = strict
-        self._available_columns = available_columns_for(self.model, self.index, self.strict)
-        self._projected_columns = validate_search_projection(self.model, self.index, self.strict, projection)
+    def prepare_projection(self, projection):
+        self._projected_columns = validate_search_projection(self.model, self.index, projection)
 
         if self._projected_columns is None:
             self._projection_mode = "count"
@@ -287,7 +279,8 @@ class PreparedSearch:
             column_blacklist = (self.index or self.model.Meta).keys
         else:
             column_blacklist = set()
-        validate_filter_condition(self.filter, self._available_columns, column_blacklist)
+        available_columns = (self.index or self.model.Meta).projection["available"]
+        validate_filter_condition(self.filter, available_columns, column_blacklist)
 
     def prepare_constraints(self, limit, forward):
         self.limit = limit

--- a/bloop/session.py
+++ b/bloop/session.py
@@ -204,13 +204,13 @@ def index_projection(index):
         "all": "ALL",
         "keys": "KEYS_ONLY",
         "include": "INCLUDE"
-    }[index.projection]
+    }[index.projection["mode"]]
 
     projection = {"ProjectionType": projection_type}
-    if index.projection == "include":
+    if index.projection["mode"] == "include":
         projection["NonKeyAttributes"] = [
             column.dynamo_name
-            for column in index.projected_columns
+            for column in index.projection["included"]
         ]
     return projection
 

--- a/docs/user/models.rst
+++ b/docs/user/models.rst
@@ -188,7 +188,8 @@ Indexes
     LocalSecondaryIndex(
         projection: Union[str, List[str]],
         range_key: str,
-        name: Optional[str]=None)
+        name: Optional[str]=None,
+        strict: bool=True)
 
 .. attribute:: projection
     :noindex:
@@ -223,6 +224,18 @@ Indexes
     :noindex:
 
     The provisioned write units for the index.  LSIs share the model's write units.  Defaults to 1.
+
+.. attribute:: strict
+    :noindex:
+
+    Whether or not queries and scans against the LSI will be allowed to access the full set of columns,
+    even when they are not projected into the LSI.  When this is True, bloop will prevent you from making
+    calls that incur additional reads against the table.  If you query or scan a Local Secondary Index
+    that has ``strict=False`` and include columns in the projection or filter expressions that are not
+    part of the LSI, DynamoDB will incur an additional read against the table in order to return all columns.
+
+    It is highly recommended to keep this enabled.  Defaults to True.
+
 
 Specific column projections always include key columns.  A query against the following ``User`` index would
 return objects that include all columns except ``created_on`` (since ``id`` and ``email`` are the model

--- a/docs/user/models.rst
+++ b/docs/user/models.rst
@@ -178,7 +178,7 @@ Indexes
 .. code-block:: python
 
     GlobalSecondaryIndex(
-        projection: Union[str, List[str]],
+        projection: Union[str, List[str], List[Column]],
         hash_key: str,
         range_key: Optional[str]=None,
         name: Optional[str]=None,
@@ -186,7 +186,7 @@ Indexes
         write_units: Optional[int]=1)
 
     LocalSecondaryIndex(
-        projection: Union[str, List[str]],
+        projection: Union[str, List[str], List[Column]],
         range_key: str,
         name: Optional[str]=None,
         strict: bool=True)
@@ -194,8 +194,9 @@ Indexes
 .. attribute:: projection
     :noindex:
 
-    The columns to project into this Index.  Must be one of ``"all"``, ``"keys"``, or a list of column names.
-    The index and model hash and range keys are always included in the projection.
+    The columns to project into this Index.  The index and model hash and range keys are always included
+    in the projection.  Must be one of ``"all"``, ``"keys"``, a list of Column objects, or a list of
+    Column model names.
 
 .. attribute:: hash_key
     :noindex:
@@ -244,7 +245,7 @@ and index hash keys).
 .. code-block:: python
 
     by_email = GlobalSecondaryIndex(
-            projection=["verified", "profile"],
+            projection=[User.verified, User.profile],
             hash_key="email")
 
 .. seealso::

--- a/docs/user/query.rst
+++ b/docs/user/query.rst
@@ -103,7 +103,6 @@ Scan and Query have very similar interfaces:
         filter=None,
         projection: Union[str, List[str]]="all",
         limit: Optional[int]=None,
-        strict: bool=True,
         consistent: bool=False,
         forward: bool=True, **kwargs) -> bloop.QueryIterator
 
@@ -112,7 +111,6 @@ Scan and Query have very similar interfaces:
         filter=None,
         projection: Union[str, List[str]]="all",
         limit: Optional[int]=None,
-        strict: bool=True,
         consistent: bool=False, **kwargs) -> bloop.ScanIterator
 
 .. attribute:: model_or_index
@@ -167,17 +165,6 @@ Scan and Query have very similar interfaces:
     object, it will not return any more (even if the internal buffer is not empty).  Defaults to None.
 
     __ http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-Limit
-
-.. _property-strict:
-
-.. attribute:: strict
-    :noindex:
-
-    Whether or not a query or scan is prevented from incurring additional reads against the table.
-    If you query or scan a Local Secondary Index without strict set to True,
-    DynamoDB will incur an additional read against the table in order to return all columns.
-
-    It is highly recommended to keep this enabled.  Defaults to True.
 
 .. _property-consistent:
 

--- a/docs/user/query.rst
+++ b/docs/user/query.rst
@@ -101,7 +101,7 @@ Scan and Query have very similar interfaces:
         model_or_index: Union[bloop.BaseModel, bloop.Index],
         key=None,
         filter=None,
-        projection: Union[str, List[str]]="all",
+        projection: Union[str, List[str], List[Column]]="all",
         limit: Optional[int]=None,
         consistent: bool=False,
         forward: bool=True, **kwargs) -> bloop.QueryIterator
@@ -109,7 +109,7 @@ Scan and Query have very similar interfaces:
     Engine.scan(
         model_or_index: Union[bloop.BaseModel, bloop.Index],
         filter=None,
-        projection: Union[str, List[str]]="all",
+        projection: Union[str, List[str], List[Column]]="all",
         limit: Optional[int]=None,
         consistent: bool=False, **kwargs) -> bloop.ScanIterator
 
@@ -153,7 +153,7 @@ Scan and Query have very similar interfaces:
 .. attribute:: projection
     :noindex:
 
-    The columns to load.  One of ``"all"``, ``"count"``, or a list of columns.
+    The columns to load.  One of ``"all"``, ``"count"``, a list of Columns, or a list of Column model names.
     When select is "count", no objects will be returned, but the ``count`` and ``scanned`` properties
     will be set on the result iterator (see below).  Defaults to "all".
 

--- a/tests/unit/test_conditions.py
+++ b/tests/unit/test_conditions.py
@@ -15,6 +15,7 @@ from bloop.conditions import (
     Or,
     iter_columns,
 )
+from bloop.exceptions import InvalidComparisonOperator
 from bloop.expressions import ConditionRenderer, render
 from bloop.models import BaseModel, Column
 from bloop.types import UUID, Integer, TypedMap
@@ -139,7 +140,7 @@ def test_not(engine):
 
 
 def test_invalid_comparator():
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidComparisonOperator):
         Comparison(User.age, "not-a-comparator", 5)
 
 

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -8,6 +8,8 @@ import pytest
 from bloop.engine import Engine, dump_key
 from bloop.exceptions import (
     AbstractModelError,
+    InvalidModel,
+    MissingKey,
     MissingObjects,
     UnboundModel,
     UnknownType,
@@ -291,7 +293,7 @@ def test_load_dump_unknown(engine):
 def test_load_missing_key(engine):
     """Trying to load objects with missing hash and range keys raises"""
     user = User(age=2)
-    with pytest.raises(ValueError):
+    with pytest.raises(MissingKey):
         engine.load(user)
 
     complex_models = [
@@ -300,7 +302,7 @@ def test_load_missing_key(engine):
         ComplexModel(date="no hash")
     ]
     for model in complex_models:
-        with pytest.raises(ValueError):
+        with pytest.raises(MissingKey):
             engine.load(model)
 
 
@@ -569,7 +571,7 @@ def test_scan(engine):
 
 def test_bind_non_model(engine):
     """Can't bind things that don't subclass BaseModel"""
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidModel):
         engine.bind(object())
 
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 
 import botocore.exceptions
 import pytest
-from bloop.exceptions import BloopException, ConstraintViolation, TableMismatch
+from bloop.exceptions import BloopException, ConstraintViolation, TableMismatch, UnknownSearchMode
 from bloop.models import Column
 from bloop.session import (
     BATCH_GET_ITEM_CHUNK_SIZE,
@@ -395,7 +395,7 @@ def test_query_scan_raise(session, dynamodb_client):
 
 
 def test_search_unknown(session):
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(UnknownSearchMode) as excinfo:
         session.search_items(mode="foo", request={})
     assert "foo" in str(excinfo.value)
 


### PR DESCRIPTION
Strict is now specified when the `LocalSecondaryIndex` is declared, instead of with every `Query` or `Scan`.  This doesn't change how the LSI is created.  The `projection` and `projected_columns` attributes of an `Index` has been refactored.  `projected_columns` is gone, and `Index.projection` has the shape:

```python
{
    "mode": Union["all", "keys", "include"],
    "included": List[Column],
    "available": List[Column],
    "strict": bool
}
```

The `strict` field is a simple way to check if `available` > `included`, but is currently unused.  Like most computed values in `BaseModel.Meta`, these values should all be considered read-only; modifying them will probably break things.

`BaseModel.Meta` now has a `projection` attribute to mirror `Index`, which means you can use the following to get a projection for an index if present, or the model:

```python
assert (index or model.Meta).projection["strict"]
```

The projection for a `BaseModel` is always fixed:

```python
{
    "mode": "all",
    "included": model.Meta.columns,
    "available": model.Meta.columns,
    "strict": True
}
```

Index and Query/Scan have a more consistent interface for `projection`:

* In addition to a list of strings, the `projection=` kwarg when declaring an `Index` can also be a list of `Column` objects.
* In addition to a list of `Column` objects, the `projection=` kwarg for `Query` and `Search` can also be a list of strings.
