### PR TITLE
Replace arrow

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Let's find them in the stream:
     >>> stream = engine.stream(Account, "trim_horizon")
     >>> next(stream)
     {'key': None,
-     'meta': {'created_at': <Arrow [...]>,
+     'meta': {'created_at': datetime.datetime(...),
       'event': {'id': 'cbb9a9b45eb0a98889b7da85913a5c65',
        'type': 'insert',
        'version': '1.1'},
@@ -102,7 +102,7 @@ Let's find them in the stream:
      'old': None}
     >>> next(stream)
     {'key': None,
-     'meta': {'created_at': <Arrow [...]>,
+     'meta': {'created_at': datetime.datetime(...),
       'event': {'id': 'cbdfac5671ea38b99017c4b43a8808ce',
        'type': 'insert',
        'version': '1.1'},

--- a/bloop/engine.py
+++ b/bloop/engine.py
@@ -287,7 +287,7 @@ class Engine:
         """Create a :class:`~bloop.stream.Stream` that provides approximate chronological ordering.
 
         :param model: The model to stream records from.
-        :param position: "trim_horizon", "latest", a stream token, or an :class:`arrow.arrow.Arrow` datetime.
+        :param position: "trim_horizon", "latest", a stream token, or a :class:`datetime.datetime`.
         :return: An iterator for records in all shards.
         :rtype: :class:`~bloop.stream.Stream`
         :raises bloop.exceptions.InvalidStream: if the model does not have a stream.

--- a/bloop/ext/arrow.py
+++ b/bloop/ext/arrow.py
@@ -1,0 +1,24 @@
+import datetime
+
+import arrow
+
+from .. import types
+
+
+DEFAULT_TIMEZONE = datetime.timezone.utc
+
+
+class DateTime(types.DateTime):
+    python_type = arrow.Arrow
+
+    def __init__(self, timezone=DEFAULT_TIMEZONE):
+        self.timezone = timezone
+        super().__init__()
+
+    def dynamo_dump(self, value, *, context, **kwargs):
+        value = value.to("utc").datetime
+        return super().dynamo_dump(value, context=context, **kwargs)
+
+    def dynamo_load(self, value, *, context, **kwargs):
+        dt = super().dynamo_load(value, context=context, **kwargs)
+        return arrow.get(dt).to(self.timezone)

--- a/bloop/ext/delorean.py
+++ b/bloop/ext/delorean.py
@@ -1,0 +1,24 @@
+import datetime
+
+import delorean
+
+from .. import types
+
+
+DEFAULT_TIMEZONE = datetime.timezone.utc
+
+
+class DateTime(types.DateTime):
+    python_type = delorean.Delorean
+
+    def __init__(self, timezone=DEFAULT_TIMEZONE):
+        self.timezone = timezone
+        super().__init__()
+
+    def dynamo_dump(self, value, *, context, **kwargs):
+        value = value.shift("utc").datetime
+        return super().dynamo_dump(value, context=context, **kwargs)
+
+    def dynamo_load(self, value, *, context, **kwargs):
+        dt = super().dynamo_load(value, context=context, **kwargs)
+        return delorean.Delorean(dt).shift(self.timezone)

--- a/bloop/ext/pendulum.py
+++ b/bloop/ext/pendulum.py
@@ -1,0 +1,24 @@
+import datetime
+
+import pendulum
+
+from .. import types
+
+
+DEFAULT_TIMEZONE = datetime.timezone.utc
+
+
+class DateTime(types.DateTime):
+    python_type = pendulum.Pendulum
+
+    def __init__(self, timezone=DEFAULT_TIMEZONE):
+        self.timezone = timezone
+        super().__init__()
+
+    def dynamo_dump(self, value, *, context, **kwargs):
+        value = value.in_timezone("utc")
+        return super().dynamo_dump(value, context=context, **kwargs)
+
+    def dynamo_load(self, value, *, context, **kwargs):
+        dt = super().dynamo_load(value, context=context, **kwargs)
+        return pendulum.instance(dt).in_timezone(self.timezone)

--- a/bloop/signals.py
+++ b/bloop/signals.py
@@ -9,7 +9,7 @@ before_create_table.__doc__ = """Sent by ``engine`` before a model's backing tab
     # Nonce table names to avoid testing collisions
     @before_create_table.connect
     def apply_table_nonce(_, model, **__):
-        nonce = arrow.now().isoformat()
+        nonce = datetime.now().isoformat()
         model.Meta.table_name += "-test-{}".format(nonce)
 
 :param engine: :class:`~bloop.engine.Engine` creating the model's table.

--- a/bloop/stream/coordinator.py
+++ b/bloop/stream/coordinator.py
@@ -1,8 +1,6 @@
 import collections
 import collections.abc
-
-import arrow
-
+import datetime
 from ..exceptions import InvalidPosition, InvalidStream, RecordsExpired
 from .buffer import RecordBuffer
 from .shard import unpack_shards
@@ -155,12 +153,12 @@ class Coordinator:
     def move_to(self, position):
         """Set the Coordinator to a specific endpoint or time, or load state from a token.
 
-        :param position: "trim_horizon", "latest", :class:`~arrow.arrow.Arrow`, or a
+        :param position: "trim_horizon", "latest", :class:`~datetime.datetime`, or a
             :attr:`Coordinator.token <bloop.stream.coordinator.Coordinator.token>`
         """
         if isinstance(position, collections.abc.Mapping):
             move = _move_stream_token
-        elif isinstance(position, arrow.Arrow):
+        elif hasattr(position, "timestamp") and callable(position.timestamp):
             move = _move_stream_time
         elif isinstance(position, str) and position.lower() in ["latest", "trim_horizon"]:
             move = _move_stream_endpoint
@@ -209,7 +207,7 @@ def _move_stream_time(coordinator, time):
 
     The corner cases are worse; short trees, recent splits, trees with different branch heights.
     """
-    if time > arrow.now():
+    if time > datetime.datetime.now(datetime.timezone.utc):
         _move_stream_endpoint(coordinator, "latest")
         return
 

--- a/bloop/stream/coordinator.py
+++ b/bloop/stream/coordinator.py
@@ -1,6 +1,7 @@
 import collections
 import collections.abc
 import datetime
+
 from ..exceptions import InvalidPosition, InvalidStream, RecordsExpired
 from .buffer import RecordBuffer
 from .shard import unpack_shards

--- a/bloop/stream/shard.py
+++ b/bloop/stream/shard.py
@@ -1,7 +1,6 @@
 import collections
 
-import arrow
-
+import datetime
 from ..exceptions import ShardIteratorExpired
 from ..util import Sentinel
 
@@ -164,29 +163,29 @@ class Shard:
         self.empty_responses = 0
 
     def seek_to(self, position):
-        """Move the Shard's iterator to the earliest record after the :class:`~arrow.arrow.Arrow` time.
+        """Move the Shard's iterator to the earliest record after the :class:`~datetime.datetime` time.
 
         Returns the first records at or past ``position``.  If the list is empty,
         the seek failed to find records, either because the Shard is exhausted or it
         reached the HEAD of an open Shard.
 
         :param position: The position in time to move to.
-        :type position: :class:`~arrow.arrow.Arrow`
+        :type position: :class:`~datetime.datetime`
         :returns: A list of the first records found after ``position``.  May be empty.
         """
         # 0) We have no way to associate the date with a position,
         #    so we have to scan the shard from the beginning.
         self.jump_to(iterator_type="trim_horizon")
 
-        position = position.timestamp
+        position = int(position.timestamp())
 
         while (not self.exhausted) and (self.empty_responses < CALLS_TO_REACH_HEAD):
             records = self.get_records()
             # We can skip the whole record set if the newest (last) record isn't new enough.
-            if records and records[-1]["meta"]["created_at"].timestamp >= position:
+            if records and records[-1]["meta"]["created_at"].timestamp() >= position:
                 # Looking for the first number *below* the position.
                 for offset, record in enumerate(reversed(records)):
-                    if record["meta"]["created_at"].timestamp < position:
+                    if record["meta"]["created_at"].timestamp() < position:
                         index = len(records) - offset
                         return records[index:]
                 return records
@@ -283,7 +282,8 @@ def reformat_record(record):
         "old": record["dynamodb"].get("OldImage", None),
 
         "meta": {
-            "created_at": arrow.get(record["dynamodb"]["ApproximateCreationDateTime"]),
+            "created_at": datetime.datetime.fromtimestamp(
+                record["dynamodb"]["ApproximateCreationDateTime"], datetime.timezone.utc),
             "event": {
                 "id": record["eventID"],
                 "type": record["eventName"].lower(),

--- a/bloop/stream/shard.py
+++ b/bloop/stream/shard.py
@@ -1,6 +1,6 @@
 import collections
-
 import datetime
+
 from ..exceptions import ShardIteratorExpired
 from ..util import Sentinel
 

--- a/bloop/stream/stream.py
+++ b/bloop/stream/stream.py
@@ -53,14 +53,14 @@ class Stream:
         This can be **very expensive**.  Once you have moved a stream to a time, you should save the
         :attr:`Stream.token <bloop.stream.stream.Stream.token>` so reloading will be extremely fast.
 
-        :param position: "trim_horizon", "latest", :class:`~arrow.arrow.Arrow`, or a
+        :param position: "trim_horizon", "latest", :class:`~datetime.datetime`, or a
             :attr:`Stream.token <bloop.stream.stream.Stream.token>`
         """
         """
 
         * Move to either endpoint of the stream with "trim_horizon" or "latest".
         * Move to a stream token (``other_stream.token``)
-        * Move to a specific time ie. ``arrow.now().replace(hours=-2)``
+        * Move to a specific time ie. ``datetime.now() - timedelta(hours=2)``
         """
         self.coordinator.move_to(position)
 

--- a/bloop/types.py
+++ b/bloop/types.py
@@ -181,20 +181,13 @@ class UUID(String):
             return None
         return str(value)
 
-
 FIXED_ISO8601_FORMAT = "%Y-%m-%dT%H:%M:%S.%f+00:00"
-"""Only this exact format, using a +00:00 suffix for UTC, will be loaded.
-Because string comparisons are used to provide ordering for comparisons,
-this **must** use a consistent format.
-"""
 
 
 class DateTime(String):
-    """DateTimes are always stored in UTC.
+    """Always stored in DynamoDB using the :data:`~bloop.types.FIXED_ISO8601_FORMAT` format.
 
-    .. warning::
-
-        Loading or saving a naive datetime will fail.  You must specify the timezone.
+    Does not support naive (no timezone) datetimes.
 
     .. code-block:: python
 
@@ -216,6 +209,21 @@ class DateTime(String):
             filter=Model.date >= one_day_ago)
 
         query.first().date
+
+    .. note::
+
+        To use common datetime libraries such as `arrow`_, `delorean`_, or `pendulum`_,
+        see :ref:`DateTime Extensions <user-extensions-datetime>` in the user guide.  These
+        are drop-in replacements and support non-utc timezones:
+
+        .. code-block:: python
+
+            from bloop import DateTime  # becomes:
+            from bloop.ext.pendulum import DateTime
+
+    .. _arrow: http://crsmithdev.com/arrow
+    .. _delorean: https://delorean.readthedocs.io/en/latest/
+    .. _pendulum: https://pendulum.eustace.io
     """
     python_type = datetime.datetime
 

--- a/docs/api/public.rst
+++ b/docs/api/public.rst
@@ -372,7 +372,7 @@ DateTime
         :annotation: = "S"
 
     .. attribute:: python_type
-        :annotation: = arrow.Arrow
+        :annotation: = datetime.datetime
 
     .. attribute:: timezone
         :annotation: = str

--- a/docs/api/public.rst
+++ b/docs/api/public.rst
@@ -3,9 +3,9 @@
 Public
 ^^^^^^
 
-======
-Engine
-======
+========
+ Engine
+========
 
 By default, Bloop will build clients directly from :func:`boto3.client`.
 To customize the engine's connection, you can provide your own DynamoDB and DynamoDBStreams clients:
@@ -25,15 +25,15 @@ To customize the engine's connection, you can provide your own DynamoDB and Dyna
 .. autoclass:: bloop.engine.Engine
     :members:
 
-======
-Models
-======
+========
+ Models
+========
 
 See :ref:`defining models <define-models>` in the User Guide.
 
----------
-BaseModel
----------
+-----------
+ BaseModel
+-----------
 
 .. autoclass:: bloop.models.BaseModel
 
@@ -42,9 +42,9 @@ BaseModel
         Holds table configuration and computed properties of the model.
         See :ref:`model meta <user-model-meta>` in the User Guide.
 
-------
-Column
-------
+--------
+ Column
+--------
 
 .. autoclass:: bloop.models.Column
     :members:
@@ -81,9 +81,9 @@ Column
 
         True if this is the model's range key.
 
---------------------
-GlobalSecondaryIndex
---------------------
+----------------------
+ GlobalSecondaryIndex
+----------------------
 
 .. autoclass:: bloop.models.GlobalSecondaryIndex
 
@@ -141,9 +141,9 @@ GlobalSecondaryIndex
 
         Provisioned write units for the index.  GSIs have their own provisioned throughput.
 
--------------------
-LocalSecondaryIndex
--------------------
+---------------------
+ LocalSecondaryIndex
+---------------------
 
 .. autoclass:: bloop.models.LocalSecondaryIndex
 
@@ -203,9 +203,9 @@ LocalSecondaryIndex
 
 .. _public-types:
 
-=====
-Types
-=====
+=======
+ Types
+=======
 
 Most custom types only need to specify a backing_type (or subclass a built-in type) and override
 :func:`~bloop.types.Type.dynamo_dump` and :func:`~bloop.types.Type.dynamo_load`:
@@ -233,9 +233,9 @@ The column will create an instance of the type by calling the constructor withou
 In rare cases, complex types may need to implement :func:`~bloop.types.Type._dump`,
 :func:`~bloop.types.Type._load`, or :func:`~bloop.types.Type._register`.
 
-----
-Type
-----
+------
+ Type
+------
 
 .. autoclass:: bloop.types.Type
     :members: dynamo_dump, dynamo_load, _dump, _load, _register
@@ -268,9 +268,9 @@ Type
 
         __ http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeValue.html
 
-------
-String
-------
+--------
+ String
+--------
 
 .. autoclass:: bloop.types.String
 
@@ -282,9 +282,9 @@ String
 
 .. _api-public-number:
 
-------
-Number
-------
+--------
+ Number
+--------
 
 You should use :class:`decimal.Decimal` instances to avoid rounding errors:
 
@@ -326,9 +326,9 @@ You should use :class:`decimal.Decimal` instances to avoid rounding errors:
 
         The context used to transfer numbers to DynamoDB.
 
-------
-Binary
-------
+--------
+ Binary
+--------
 
 .. autoclass:: bloop.types.Binary
 
@@ -338,9 +338,9 @@ Binary
     .. attribute:: python_type
         :annotation: = bytes
 
--------
-Boolean
--------
+---------
+ Boolean
+---------
 
 .. autoclass:: bloop.types.Boolean
 
@@ -350,9 +350,9 @@ Boolean
     .. attribute:: python_type
         :annotation: = bool
 
-----
-UUID
-----
+------
+ UUID
+------
 
 .. autoclass:: bloop.types.UUID
 
@@ -362,9 +362,17 @@ UUID
     .. attribute:: python_type
         :annotation: = uuid.UUID
 
---------
-DateTime
---------
+----------
+ DateTime
+----------
+
+.. data:: bloop.types.FIXED_ISO8601_FORMAT
+    :annotation:
+
+    DateTimes **must** be stored in DynamoDB in UTC with this exact format, and a +00:00 suffix.
+    This is necessary for using comparison operators such as ``>`` and ``<=`` on DateTime instance.
+
+    You must not use "Z" or any other suffix than "+00:00" to indicate UTC.  You must not omit the timezone specifier.
 
 .. autoclass:: bloop.types.DateTime
 
@@ -374,14 +382,9 @@ DateTime
     .. attribute:: python_type
         :annotation: = datetime.datetime
 
-    .. attribute:: timezone
-        :annotation: = str
-
-        The timezone used for local values.
-
--------
-Integer
--------
+---------
+ Integer
+---------
 
 .. autoclass:: bloop.types.Integer
 
@@ -396,9 +399,9 @@ Integer
 
         The context used to transfer numbers to DynamoDB.
 
----
-Set
----
+-----
+ Set
+-----
 
 .. autoclass:: bloop.types.Set
 
@@ -416,9 +419,9 @@ Set
 
         The typedef for values in this Set.  Has a backing type of "S", "N", or "B".
 
-----
-List
-----
+------
+ List
+------
 
 .. autoclass:: bloop.types.List
 
@@ -433,9 +436,9 @@ List
 
         The typedef for values in this List.  All types supported.
 
----
-Map
----
+-----
+ Map
+-----
 
 .. autoclass:: bloop.types.Map
 
@@ -458,9 +461,9 @@ Map
                 "rating": Number()
             }
 
-=====
-Query
-=====
+=======
+ Query
+=======
 
 .. autoclass:: bloop.search.QueryIterator
 
@@ -489,9 +492,9 @@ Query
 
         Number of items that DynamoDB evaluated, before any filter was applied.
 
-====
-Scan
-====
+======
+ Scan
+======
 
 .. autoclass:: bloop.search.ScanIterator
 
@@ -520,9 +523,9 @@ Scan
 
         Number of items that DynamoDB evaluated, before any filter was applied.
 
-======
-Stream
-======
+========
+ Stream
+========
 
 :func:`Engine.stream() <bloop.engine.Engine.stream>` is the recommended way to create a stream.
 If you manually create a stream, you will need to call :func:`~bloop.stream.Stream.move_to` before iterating the
@@ -547,9 +550,9 @@ Stream.
 .. autoclass:: bloop.stream.Stream
     :members:
 
-==========
-Conditions
-==========
+============
+ Conditions
+============
 
 The only public class the conditions system exposes is the empty condition, :class:`~bloop.conditions.Condition`.
 The rest of the conditions system is baked into :class:`~bloop.models.Column` and consumed by the various
@@ -576,9 +579,9 @@ value.  The model's ``Meta`` attribute describes the required keys:
 
 .. _public-signals:
 
-=======
-Signals
-=======
+=========
+ Signals
+=========
 
 .. autodata:: bloop.signals.before_create_table
     :annotation:
@@ -604,9 +607,9 @@ Signals
 .. autodata:: bloop.signals.model_validated
     :annotation:
 
-==========
-Exceptions
-==========
+============
+ Exceptions
+============
 
 Except to configure sessions, Bloop aims to completely abstract the boto3/botocore layers.  If you encounter an
 exception from either boto3 or botocore, please `open an issue`__.  Bloop's exceptions are broadly divided into two
@@ -626,9 +629,9 @@ To catch any exception from Bloop, use :exc:`~bloop.exceptions.BloopException`:
 
 __ https://github.com/numberoverzero/bloop/issues/new
 
-----------------
-Unexpected state
-----------------
+------------------
+ Unexpected state
+------------------
 
 These are exceptions that you should be ready to handle in the normal course of using DynamoDB.  For example,
 failing to load objects will raise :exc:`~bloop.exceptions.MissingObjects`, while conditional operations may
@@ -644,9 +647,9 @@ fail with :exc`~bloop.exceptions.ConstraintViolation`.
 
 .. autoclass:: bloop.exceptions.TableMismatch
 
----------
-Bad Input
----------
+-----------
+ Bad Input
+-----------
 
 These are thrown when an option is invalid or missing, such as forgetting a key condition for a query,
 or trying to use an unknown projection type.
@@ -679,3 +682,46 @@ or trying to use an unknown projection type.
 
 .. autoclass:: bloop.exceptions.UnknownType
 
+.. _public-extensions:
+
+============
+ Extensions
+============
+
+.. _public-ext-datetime:
+
+----------
+ DateTime
+----------
+
+.. class:: DateTime(timezone=datetime.timezone.utc)
+
+    Drop-in replacement for :class:`~bloop.types.DateTime`.  Support for `arrow`_, `delorean`_, and `pendulum`_:
+
+    .. code-block:: python
+
+        from bloop.ext.arrow import DateTime
+        from bloop.ext.delorean import DateTime
+        from bloop.ext.pendulum import DateTime
+
+    .. attribute:: backing_type
+        :annotation: = "S"
+
+    .. attribute:: python_type
+        :annotation:
+
+        Depending on where it's imported from, one of:
+
+        * :class:`arrow.Arrow <arrow.arrow.Arrow>`
+        * :class:`delorean.Delorean`
+        * :class:`pendulum.Pendulum`
+
+    .. attribute:: timezone
+        :annotation: = tzinfo
+
+        The timezone that values loaded from DynamoDB will use.  Note that DateTimes are always stored in DynamoDB
+        according to :data:`~bloop.types.FIXED_ISO8601_FORMAT`.
+
+.. _arrow: http://crsmithdev.com/arrow
+.. _delorean: https://delorean.readthedocs.io/en/latest/
+.. _pendulum: https://pendulum.eustace.io

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,8 @@ intersphinx_mapping = {
     'arrow': ('https://arrow.readthedocs.io/en/latest/', None),
     'PIL': ('https://pillow.readthedocs.io/en/3.4.x', None),
     'blinker': ('https://pythonhosted.org/blinker/', None),
-    'boto3': ('http://boto3.readthedocs.io/en/latest', None)
+    'boto3': ('http://boto3.readthedocs.io/en/latest', None),
+    'delorean': ('https://delorean.readthedocs.io/en/latest/', None)
 }
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,6 +89,7 @@ Get started by :ref:`installing <user-install>` Bloop, or check out a :ref:`larg
     user/conditions
     user/signals
     user/patterns
+    user/extensions
 
 .. toctree::
     :maxdepth: 2

--- a/docs/meta/about.rst
+++ b/docs/meta/about.rst
@@ -20,6 +20,8 @@ To start developing Bloop first `create a fork`_, then clone and run the tests::
 Versioning
 ==========
 
+.. _meta-versioning-public:
+
 ----------
 Public API
 ----------

--- a/docs/user/engine.rst
+++ b/docs/user/engine.rst
@@ -77,10 +77,12 @@ Saving an item or items is very simple:
 
 .. code-block:: pycon
 
+    >>> from datetime import datetime, timezone
+    >>> now = datetime.now(timezone.utc)
     >>> user = User(...)
     >>> engine.save(user)
     >>> tweet = Tweet(...)
-    >>> user.last_activity = arrow.now()
+    >>> user.last_activity = now
     >>> engine.save(user, tweet)
 
 You can perform optimistic saves with a ``condition``.  If a condition is not met when DynamoDB tries to apply the
@@ -140,9 +142,11 @@ shorthand to only delete objects unchanged since you last loaded them from Dynam
 
 .. code-block:: pycon
 
+    >>> from datetime import datetime, timedelta, timezone
     >>> engine.delete(user, tweet)
     >>> engine.delete(tps_report, atomic=True)
-    >>> cutoff = arrow.now().repalce(years=-2)
+    >>> now = datetime.now(timezone.utc)
+    >>> cutoff = now - timedelta(years=2)
     >>> engine.delete(
     ...     account,
     ...     condition=Account.last_login < cutoff)
@@ -296,8 +300,11 @@ Here is the same LSI query as above, but now excluding accounts created in the l
 
 .. code-block:: pycon
 
+    >>> from datetime import datetime, timedelta, timezone
+    >>> now = datetime.now(timezone.utc)
+    >>> recent = now - timedelta(days=30)
     >>> key_condition = owned_by_stacy & at_least_one_mil
-    >>> exclude_recent = Account.created_on < arrow.now().replace(days=-30)
+    >>> exclude_recent = Account.created_on < recent
     >>> q = engine.query(Account.by_balance,
     ...     key=key_condition,
     ...     filter=exclude_recent)
@@ -472,10 +479,12 @@ Alternatively, you can use an existing stream token to reload its previous state
     >>> same_stream = engine.stream(
     ...     Impression, previous_stream.token)
 
-Lastly, you can use an arrow datetime.  This is an **expensive call**, and walks the entire stream from the trim
+Lastly, you can use a datetime.  This is an **expensive call**, and walks the entire stream from the trim
 horizon until it finds the first record in each shard after the target datetime.
 
 .. code-block:: pycon
 
-    >>> yesterday = arrow.now().replace(hours=-12)
+    >>> from datetime import datetime, timedelta, timezone
+    >>> now = datetime.now(timezone.utc)
+    >>> yesterday = now - timedelta(hours=12)
     >>> stream = engine.stream(User, yesterday)

--- a/docs/user/extensions.rst
+++ b/docs/user/extensions.rst
@@ -1,0 +1,84 @@
+Bloop Extensions
+^^^^^^^^^^^^^^^^
+
+Extensions' dependencies aren't installed with Bloop, because they may include a huge number of libraries that Bloop
+does not depend on.  For example, two extensions could provide automatic mapping to Django or SQLAlchemy models.
+Many users would never need either of these, since Bloop does not depend on them for normal usage.
+
+Bloop extensions are part of the :ref:`Public API <public-extensions>`, and subject to
+:ref:`its versioning policy<meta-versioning-public>`.
+
+.. _user-extensions-datetime:
+
+==========
+ DateTime
+==========
+
+Working with python's :class:`datetime.datetime` is tedious, but there are a number of popular libraries
+that improve the situation.  Bloop includes drop-in replacements for the basic
+:class:`~bloop.types.DateTime` type for `arrow`_, `delorean`_, and `pendulum`_ through the
+:ref:`extensions module<public-ext-datetime>`.  For example, let's swap out some code using the built-in DateTime:
+
+.. code-block:: python
+    :emphasize-lines: 1, 2, 9, 10
+
+    import datetime
+    from bloop import DateTime
+    from bloop import BaseModel, Column, Integer
+
+    class User(BaseModel):
+        id = Column(Integer, hash_key=True)
+        created_on = Column(DateTime)
+
+    utc = datetime.timezone.utc
+    now = datetime.datetime.now(utc)
+
+    user = User
+        id=0,
+        created_on=now
+    )
+
+Now, using pendulum:
+
+.. code-block:: python
+    :emphasize-lines: 1, 2, 9
+
+    import pendulum
+    from bloop.ext.pendulum import DateTime
+    from bloop import BaseModel, Column, Integer
+
+    class User(BaseModel):
+        id = Column(Integer, hash_key=True)
+        created_on = Column(DateTime)
+
+    now = pendulum.now("utc")
+
+    user = User
+        id=0,
+        created_on=now
+    )
+
+Now, using arrow:
+
+.. code-block:: python
+    :emphasize-lines: 1, 2, 9
+
+    import arrow
+    from bloop.ext.arrow import DateTime
+    from bloop import BaseModel, Column, Integer
+
+    class User(BaseModel):
+        id = Column(Integer, hash_key=True)
+        created_on = Column(DateTime)
+
+    now = arrow.now("utc")
+
+    user = User
+        id=0,
+        created_on=now
+    )
+
+..
+.. _arrow: http://crsmithdev.com/arrow
+.. _delorean: https://delorean.readthedocs.io/en/latest/
+.. _pendulum: https://pendulum.eustace.io

--- a/docs/user/models.rst
+++ b/docs/user/models.rst
@@ -70,16 +70,17 @@ The default ``__init__`` takes \*\*kwargs and applies them by each column's mode
 
 .. code-block:: pycon
 
-    >>> import arrow, uuid
+    >>> import datetime, uuid
+    >>> now = datetime.datetime.now(datetime.timezone.utc)
     >>> user = User(
     ...     id=uuid.uuid4(),
     ...     version="1",
     ...     email="user@domain.com",
-    ...     created_at=arrow.now())
+    ...     created_at=now)
     >>> user.email
     'user@domain.com'
     >>> user
-    User(created_on=<Arrow [2016-10-29T22:08:08.930137-07:00]>, ...)
+    User(created_on=datetime.datetime(2016, 10, 29, ...), ...)
 
 A local object's hash and range keys don't need values until you're ready to interact with DynamoDB:
 

--- a/docs/user/patterns.rst
+++ b/docs/user/patterns.rst
@@ -3,9 +3,9 @@ Bloop Patterns
 
 .. _patterns-local:
 
-==============
-DynamoDB Local
-==============
+================
+ DynamoDB Local
+================
 
 Connect to a local DynamoDB instance.
 
@@ -27,9 +27,9 @@ Connect to a local DynamoDB instance.
 
 .. _patterns-if-not-exist:
 
-======================
-Generic "if not exist"
-======================
+========================
+ Generic "if not exist"
+========================
 
 Create a condition for any model or object that fails the operation if the item already exists.
 
@@ -51,9 +51,9 @@ Create a condition for any model or object that fails the operation if the item 
 
 .. _patterns-float:
 
-==========
-Float Type
-==========
+============
+ Float Type
+============
 
 A number type with a :class:`decimal.Context` that doesn't trap :class:`decimal.Rounded` or :class:`decimal.Inexact`.
 

--- a/docs/user/streams.rst
+++ b/docs/user/streams.rst
@@ -68,13 +68,13 @@ Next, create a stream on the model.  This example starts at "trim_horizon" to ge
 
     >>> stream = engine.stream(User, "trim_horizon")
 
-If you want to start at a certain point in time, you can also use an :class:`arrow.arrow.Arrow` datetime.
+If you want to start at a certain point in time, you can also use a :class:`datetime.datetime`.
 Creating streams at a specific time is **very expensive**, and will iterate all records since the stream's
 trim_horizon until the target time.
 
 .. code-block:: pycon
 
-    >>> stream = engine.stream(User, arrow.now().replace(hours=-12))
+    >>> stream = engine.stream(User, datetime.now() - timedelta(hours=12))
 
 If you are trying to resume processing from the same position as another stream, you should load from a persisted
 :data:`Stream.token <bloop.stream.Stream.token>` instead of using a specific time.
@@ -142,7 +142,7 @@ The first record won't have an old value, since it was the first time this item 
      'old': None,
      'new': User(email='user@domain.com', id=3, verified=None),
      'meta': {
-         'created_at': <Arrow [2016-10-23T00:28:00-07:00]>,
+         'created_at': datetime.datetime(2016, 10, 23, ...),
          'event': {
              'id': '3fe6d339b7cb19a1474b3d853972c12a',
              'type': 'insert',
@@ -159,7 +159,7 @@ The second record shows the change to email, and has both old and new objects:
      'old': User(email='user@domain.com', id=3, verified=None),
      'new': User(email='admin@domain.com', id=3, verified=None),
      'meta': {
-         'created_at': <Arrow [2016-10-23T00:28:00-07:00]>,
+         'created_at': datetime.datetime(2016, 10, 23, ...),
          'event': {
              'id': '73a4b8568a85a0bcac25799f806df239',
              'type': 'modify',
@@ -247,7 +247,7 @@ This function takes the same ``position`` argument as :func:`Engine.stream <bloo
     >>> stream.move_to(stream.token)
 
     # Jump back in time 2 hours
-    >>> stream.move_to(arrow.now().replace(hours=-2))
+    >>> stream.move_to(datetime.now() - timedelta(hours=2))
 
     # Move to the oldest record in the stream
     >>> stream.move_to("trim_horizon")

--- a/docs/user/streams.rst
+++ b/docs/user/streams.rst
@@ -186,12 +186,16 @@ The following pattern will call heartbeat every 12 minutes (if record processing
 
 .. code-block:: pycon
 
-    >>> next_heartbeat = arrow.now()
+    >>> from datetime import datetime, timedelta
+    >>> now = datetime.now
+    >>> future = lambda: datetime.now() + timedelta(minutes=12)
+    >>>
+    >>> next_heartbeat = now()
     >>> while True:
     ...     record = next(stream)
     ...     process(record)
-    ...     if arrow.now() > next_heartbeat:
-    ...         next_heartbeat = arrow.now().replace(minutes=12)
+    ...     if now() > next_heartbeat:
+    ...         next_heartbeat = future()
     ...         stream.heartbeat()
 
 .. _stream-resume:

--- a/docs/user/types.rst
+++ b/docs/user/types.rst
@@ -5,7 +5,7 @@ Types
 
 Types are used when defining :ref:`Columns <user-models-columns>` and are responsible for translating between
 local values and their DynamoDB representations.  For example, :class:`~bloop.types.DateTime` maps between
-``arrow.now()`` and ``"2016-08-09T01:16:25.322849+00:00"``.
+``datetime.now(timezone.utc)`` and ``"2016-08-09T01:16:25.322849+00:00"``.
 
 DynamoDB is split into scalar types ("S", "N", "B", "BOOL") and vector types ("SS", "NS", "BS", "L", "M").
 Bloop provides corresponding types, as well as a handful of useful derived types, such as DateTime and UUID.
@@ -121,7 +121,8 @@ and not just the primitive types above.
 
 .. code-block:: python
 
-    import arrow, uuid
+    import uuid
+    from datetime import datetime, timezone
     from bloop import DateTime, UUID, Integer
 
 
@@ -133,7 +134,7 @@ and not just the primitive types above.
     tweet = Tweet(
         account_id=3,
         tweet_id=uuid.uuid4(),
-        created_at=arrow.now()
+        created_at=datetime.now(timezone.utc)
     )
 
 .. note::
@@ -252,7 +253,7 @@ Only defined keys will be loaded or saved.  In the following, the impression's "
 
     impression = Impression(id=uuid.uuid4())
     impression.metadata = {
-        "created": arrow.now(),
+        "created": datetime.now(timezone.utc),
         "referrer": referrer.id,
         "cache": "https://img-cache.s3.amazonaws.com/" + img.filename,
         "version": 1.1  # NOT SAVED

--- a/examples/documents.py
+++ b/examples/documents.py
@@ -1,8 +1,8 @@
 import decimal
 import random
 import uuid
+from datetime import datetime, timezone
 
-import arrow
 from bloop import (
     UUID,
     BaseModel,
@@ -49,7 +49,7 @@ item = Item(id=uuid.uuid4())
 item.data = {
     'Name': 'item-name',
     'Rating': decimal.Decimal(str(random.random())),
-    'Updated': arrow.now(),
+    'Updated': datetime.now(timezone.utc),
     'Description': {
         'Title': 'item-title',
         'Body': 'item-body',

--- a/examples/tweet.py
+++ b/examples/tweet.py
@@ -1,6 +1,6 @@
 import uuid
+from datetime import datetime, timezone
 
-import arrow
 from bloop import (
     UUID,
     BaseModel,
@@ -57,6 +57,6 @@ tweet = Tweet(
     account=account.id, id='616102582239399936',
     content='today, I wrote a type validator in Python, as you do',
     favorites=9,
-    date=arrow.now())
+    date=datetime.now(timezone.utc))
 
 engine.save(account, tweet)

--- a/requirements-to-freeze.txt
+++ b/requirements-to-freeze.txt
@@ -4,7 +4,9 @@ blinker
 boto3
 coverage
 declare
+delorean
 flake8
+pendulum
 pip
 pytest
 sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,9 @@ blinker==1.4
 boto3==1.4.1
 coverage==4.2
 declare==0.9.11
+delorean==0.6.0
 flake8==3.0.4
+pendulum==0.6.5
 pytest==3.0.3
 Sphinx==1.4.8
 sphinx_rtd_theme==0.1.9

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ def get_version():
 
 PACKAGES = [
     "bloop",
-    "bloop.ext"
+    "bloop.ext",
+    "bloop.stream"
 ]
 
 REQUIREMENTS = [

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """ Setup file """
 import os
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -15,19 +15,15 @@ def get_version():
             if line.startswith("__version__"):
                 return eval(line.split("=")[-1])
 
+PACKAGES = [
+    "bloop",
+    "bloop.ext"
+]
+
 REQUIREMENTS = [
     "blinker==1.4",
     "boto3==1.4.1",
     "declare==0.9.11",
-]
-
-TEST_REQUIREMENTS = [
-    "alabaster",
-    "coverage",
-    "flake8",
-    "pytest",
-    "sphinx",
-    "tox",
 ]
 
 if __name__ == "__main__":
@@ -53,7 +49,6 @@ if __name__ == "__main__":
         keywords="aws dynamo dynamodb orm",
         platforms="any",
         include_package_data=True,
-        packages=find_packages(exclude=("tests", "docs", "examples")),
+        packages=PACKAGES,
         install_requires=REQUIREMENTS,
-        tests_require=REQUIREMENTS + TEST_REQUIREMENTS,
     )

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,10 @@ def get_version():
                 return eval(line.split("=")[-1])
 
 REQUIREMENTS = [
-    "arrow==0.8.0",
+    "arrow==0.8.0",  # TODO remove
     "blinker==1.4",
     "boto3==1.4.1",
-    "declare==0.9.11"
+    "declare==0.9.11",
 ]
 
 TEST_REQUIREMENTS = [

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ def get_version():
                 return eval(line.split("=")[-1])
 
 REQUIREMENTS = [
-    "arrow==0.8.0",  # TODO remove
     "blinker==1.4",
     "boto3==1.4.1",
     "declare==0.9.11",

--- a/tests/unit/test_conditions.py
+++ b/tests/unit/test_conditions.py
@@ -25,7 +25,7 @@ from bloop.conditions import (
 )
 from bloop.models import BaseModel, Column
 from bloop.signals import object_deleted, object_loaded, object_saved
-from bloop.types import String, Binary, Integer, Set, List, Map, Boolean
+from bloop.types import Binary, Boolean, Integer, List, Map, Set, String
 
 from ..helpers.models import Document, User
 

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -1,6 +1,6 @@
+import datetime
 from unittest.mock import Mock
 
-import datetime
 import pytest
 from bloop.engine import Engine, dump_key
 from bloop.exceptions import (

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock
 
-import arrow
+import datetime
 import pytest
 from bloop.engine import Engine, dump_key
 from bloop.exceptions import (
@@ -179,7 +179,7 @@ def test_load_shared_table(engine, session):
 
     id = "foo"
     range = "bar"
-    now = arrow.now().to("utc")
+    now = datetime.datetime.now(datetime.timezone.utc)
     now_str = now.isoformat()
     session.load_items.return_value = {
         "SharedTable": [{

--- a/tests/unit/test_ext/test_arrow.py
+++ b/tests/unit/test_ext/test_arrow.py
@@ -1,0 +1,21 @@
+import pytest
+import arrow
+from bloop.types import FIXED_ISO8601_FORMAT
+from datetime import datetime
+import pytz
+
+from bloop.ext.arrow import DateTime
+
+
+now = datetime.now(pytz.utc)
+now_eastern = datetime.now(pytz.timezone("US/Eastern"))
+now_iso8601 = now.strftime(FIXED_ISO8601_FORMAT)
+
+
+@pytest.mark.parametrize("timezone", ["utc", "US/Eastern"])
+def test_datetime(timezone):
+    arrow_now = arrow.get(now)
+    typedef = DateTime(timezone)
+
+    assert typedef.dynamo_dump(arrow_now, context={}) == now_iso8601
+    assert typedef.dynamo_load(now_iso8601, context={}).to("utc").datetime == now

--- a/tests/unit/test_ext/test_delorean.py
+++ b/tests/unit/test_ext/test_delorean.py
@@ -1,0 +1,21 @@
+import pytest
+import delorean
+from bloop.types import FIXED_ISO8601_FORMAT
+from datetime import datetime
+import pytz
+
+from bloop.ext.delorean import DateTime
+
+
+now = datetime.now(pytz.utc)
+now_eastern = datetime.now(pytz.timezone("US/Eastern"))
+now_iso8601 = now.strftime(FIXED_ISO8601_FORMAT)
+
+
+@pytest.mark.parametrize("timezone", ["utc", "US/Eastern"])
+def test_datetime(timezone):
+    delorean_now = delorean.Delorean(now)
+    typedef = DateTime(timezone)
+
+    assert typedef.dynamo_dump(delorean_now, context={}) == now_iso8601
+    assert typedef.dynamo_load(now_iso8601, context={}).shift("utc").datetime == now

--- a/tests/unit/test_ext/test_pendulum.py
+++ b/tests/unit/test_ext/test_pendulum.py
@@ -1,0 +1,21 @@
+import pytest
+import pendulum
+from bloop.types import FIXED_ISO8601_FORMAT
+from datetime import datetime
+import pytz
+
+from bloop.ext.pendulum import DateTime
+
+
+now = datetime.now(pytz.utc)
+now_eastern = datetime.now(pytz.timezone("US/Eastern"))
+now_iso8601 = now.strftime(FIXED_ISO8601_FORMAT)
+
+
+@pytest.mark.parametrize("timezone", ["utc", "US/Eastern"])
+def test_datetime(timezone):
+    delorean_now = pendulum.instance(now)
+    typedef = DateTime(timezone)
+
+    assert typedef.dynamo_dump(delorean_now, context={}) == now_iso8601
+    assert typedef.dynamo_load(now_iso8601, context={}).in_timezone("utc") == now

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,6 +1,6 @@
 import operator
 
-import arrow
+import datetime
 import pytest
 from bloop.conditions import ConditionRenderer
 from bloop.exceptions import InvalidIndex, InvalidModel, InvalidStream
@@ -75,13 +75,13 @@ def test_load_default_init(engine):
 def test_load_dump(engine):
     """_load and _dump should be symmetric"""
     user = User(id="user_id", name="test-name", email="email@domain.com", age=31,
-                joined=arrow.now())
+                joined=datetime.datetime.now(datetime.timezone.utc))
     serialized = {
         "id": {"S": user.id},
         "age": {"N": "31"},
         "name": {"S": "test-name"},
         "email": {"S": "email@domain.com"},
-        "j": {"S": user.joined.to("utc").isoformat()}
+        "j": {"S": user.joined.isoformat()}
     }
 
     loaded_user = engine._load(User, serialized)

--- a/tests/unit/test_stream/__init__.py
+++ b/tests/unit/test_stream/__init__.py
@@ -1,4 +1,5 @@
 import datetime
+
 from bloop.stream.shard import Shard
 from bloop.util import Sentinel
 

--- a/tests/unit/test_stream/__init__.py
+++ b/tests/unit/test_stream/__init__.py
@@ -1,4 +1,4 @@
-import arrow
+import datetime
 from bloop.stream.shard import Shard
 from bloop.util import Sentinel
 
@@ -65,7 +65,8 @@ def dynamodb_record_with(key=False, new=False, old=False, sequence_number=None, 
     if creation_time is None:
         creation_time = 1.46480527E9
     else:
-        creation_time = creation_time.timestamp
+        creation_time = creation_time.timestamp()
+    creation_time = int(creation_time)
     template = {
         "awsRegion": "us-west-2",
         "dynamodb": {
@@ -100,7 +101,7 @@ def dynamodb_record_with(key=False, new=False, old=False, sequence_number=None, 
 
 def local_record(created_at=missing, sequence_number="default-sequence-number"):
     if created_at is missing:
-        created_at = arrow.now()
+        created_at = datetime.datetime.now(datetime.timezone.utc)
     return {
         "meta": {
             "created_at": created_at,

--- a/tests/unit/test_stream/test_buffer.py
+++ b/tests/unit/test_stream/test_buffer.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock
 
-import arrow
+import datetime
 import pytest
 from bloop.stream.buffer import RecordBuffer, heap_item
 from bloop.stream.shard import Shard
@@ -18,11 +18,15 @@ def new_clock():
     return call
 
 
+def now():
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
 def new_shard() -> Shard:
     return Mock(spec=Shard)
 
 
-@pytest.mark.parametrize("created_at", [None, arrow.now()])
+@pytest.mark.parametrize("created_at", [None, now()])
 @pytest.mark.parametrize("sequence_number", [None, 2])
 def test_heap_item_clock(created_at, sequence_number):
     """heap_item guarantees total ordering, even for identical items."""
@@ -42,7 +46,7 @@ def test_heap_item_clock(created_at, sequence_number):
     assert clock() == 3
 
 
-@pytest.mark.parametrize("created_at", [None, arrow.now()])
+@pytest.mark.parametrize("created_at", [None, now()])
 @pytest.mark.parametrize("sequence_number", [None, 2])
 def test_heap_item_broken_clock(created_at, sequence_number):
     """When the clock can return the same value, total ordering is lost."""
@@ -69,7 +73,7 @@ def test_empty_buffer():
 
 def test_single_record():
     """Push a record, peek at it, then get the same thing back"""
-    record = local_record(arrow.now(), 1)
+    record = local_record(now(), 1)
     shard = new_shard()
     buffer = RecordBuffer()
 
@@ -87,8 +91,8 @@ def test_single_record():
 
 def test_sort_every_push():
     """Push high to low, retrieve low to high"""
-    now = arrow.now()
-    records = [local_record(now, i) for i in reversed(range(5))]
+    now_ = now()
+    records = [local_record(now_, i) for i in reversed(range(5))]
     shard = new_shard()
     buffer = RecordBuffer()
 
@@ -107,8 +111,8 @@ def test_sort_every_push():
 
 def test_push_all():
     """Bulk push is slightly more efficient"""
-    now = arrow.now()
-    records = [local_record(now, i) for i in reversed(range(5))]
+    now_ = now()
+    records = [local_record(now_, i) for i in reversed(range(5))]
     shard = new_shard()
     buffer = RecordBuffer()
 
@@ -124,7 +128,7 @@ def test_push_all():
 
 
 def test_clear():
-    record = local_record(arrow.now(), 1)
+    record = local_record(now(), 1)
     shard = new_shard()
     buffer = RecordBuffer()
 
@@ -137,7 +141,7 @@ def test_clear():
 
 def test_buffer_heap():
     """RecordBuffer directly exposes its heap"""
-    record = local_record(arrow.now(), 1)
+    record = local_record(now(), 1)
     shard = new_shard()
     buffer = RecordBuffer()
 

--- a/tests/unit/test_stream/test_buffer.py
+++ b/tests/unit/test_stream/test_buffer.py
@@ -1,6 +1,6 @@
+import datetime
 from unittest.mock import Mock
 
-import datetime
 import pytest
 from bloop.stream.buffer import RecordBuffer, heap_item
 from bloop.stream.shard import Shard

--- a/tests/unit/test_stream/test_coordinator.py
+++ b/tests/unit/test_stream/test_coordinator.py
@@ -2,7 +2,7 @@ import collections
 import functools
 from unittest.mock import call
 
-import arrow
+import datetime
 import pytest
 from bloop.exceptions import InvalidPosition, InvalidStream, RecordsExpired
 from bloop.stream.shard import CALLS_TO_REACH_HEAD, Shard, last_iterator
@@ -403,7 +403,7 @@ def test_move_to_future_time(coordinator, session):
     expected_active_ids = ["shard-id-{}".format(i) for i in [2, 3, 5, 7]]
     session.get_shard_iterator.return_value = "child-iterator-id"
 
-    coordinator.move_to(arrow.now().replace(hours=1))
+    coordinator.move_to(datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1))
 
     # Remote calls - no new records fetched, loaded child shards and jumped to their latest
     session.get_stream_records.assert_not_called()
@@ -423,7 +423,7 @@ def test_move_to_future_time(coordinator, session):
 
 def test_move_to_datetime(coordinator, session):
     """Move to a time somewhere in the middle of a stream"""
-    position = arrow.now()
+    position = datetime.datetime.now(datetime.timezone.utc)
 
     # 0 -> 1
     #   -> 2 -> 3
@@ -441,7 +441,7 @@ def test_move_to_datetime(coordinator, session):
     record = dynamodb_record_with(
         key=True,
         sequence_number="found-record-sequence-number",
-        creation_time=position.replace(hours=1))
+        creation_time=position + datetime.timedelta(hours=1))
 
     responses = {
         # Shard 0 will immediately exhaust without finding records

--- a/tests/unit/test_stream/test_coordinator.py
+++ b/tests/unit/test_stream/test_coordinator.py
@@ -1,8 +1,8 @@
 import collections
+import datetime
 import functools
 from unittest.mock import call
 
-import datetime
 import pytest
 from bloop.exceptions import InvalidPosition, InvalidStream, RecordsExpired
 from bloop.stream.shard import CALLS_TO_REACH_HEAD, Shard, last_iterator

--- a/tests/unit/test_stream/test_shard.py
+++ b/tests/unit/test_stream/test_shard.py
@@ -1,9 +1,8 @@
+import datetime
 import random
 from unittest.mock import call
 
 import pytest
-import datetime
-
 from bloop.exceptions import ShardIteratorExpired
 from bloop.stream.shard import (
     CALLS_TO_REACH_HEAD,

--- a/tests/unit/test_stream/test_stream.py
+++ b/tests/unit/test_stream/test_stream.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
+import datetime
 
-import arrow
 import pytest
 from bloop.models import BaseModel, Column
 from bloop.stream.coordinator import Coordinator
@@ -86,7 +86,7 @@ def test_next_no_record(stream, coordinator):
 
 
 def test_next_unpacks(stream, coordinator):
-    now = arrow.now()
+    now = datetime.datetime.now(datetime.timezone.utc)
     meta = {
         "created_at": now,
         "sequence_number": "sequence-number",

--- a/tests/unit/test_stream/test_stream.py
+++ b/tests/unit/test_stream/test_stream.py
@@ -1,5 +1,5 @@
-from unittest.mock import MagicMock
 import datetime
+from unittest.mock import MagicMock
 
 import pytest
 from bloop.models import BaseModel, Column

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1,7 +1,7 @@
 import decimal
 import uuid
 
-import arrow
+import datetime
 import declare
 import pytest
 from bloop.types import (
@@ -139,24 +139,9 @@ def test_uuid():
 
 def test_datetime():
     typedef = DateTime()
-
-    tz = "Europe/Paris"
-    now = arrow.now()
-
-    # Not a symmetric type
-    assert typedef.dynamo_load(now.isoformat(), context={}) == now
-    assert typedef.dynamo_dump(now, context={}) == now.to("utc").isoformat()
-
-    assert now == typedef.dynamo_load(now.to(tz).isoformat(), context={})
-    assert now.to("utc").isoformat() == typedef.dynamo_dump(now.to(tz), context={})
-
-    # Should load values in the given timezone.
-    # Because arrow objects compare equal regardless of timezone, we
-    # isoformat each to compare the rendered strings (which preserve tz).
-    local_typedef = DateTime(timezone=tz)
-    loaded_as_string = local_typedef.dynamo_load(now.isoformat(), context={}).isoformat()
-    now_with_tz_as_string = now.to(tz).isoformat()
-    assert loaded_as_string == now_with_tz_as_string
+    now = datetime.datetime.now(datetime.timezone.utc)
+    now_str = now.isoformat()
+    symmetric_test(typedef, (now, now_str))
 
 
 def test_number():
@@ -277,7 +262,7 @@ def test_list_path(key):
 
 def test_map_dump(engine):
     """Map handles nested maps and custom types"""
-    now = arrow.now().to('utc')
+    now = datetime.datetime.now(datetime.timezone.utc)
     loaded = {
         'Rating': 0.5,
         'Stock': 3,

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-basepython=python3.5
 envlist = unit, integ, docs
 
+[testenv]
+basepython = python3.5
+deps = -rrequirements.txt
+
 [testenv:unit]
-deps =
-    pytest
-    coverage
-    flake8
 commands =
     coverage run --branch --source=bloop -m py.test tests/unit {posargs}
     coverage report -m
@@ -14,14 +13,10 @@ commands =
 
 [testenv:integ]
 passenv = AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-deps = pytest
 commands = py.test tests/integ -vv {posargs}
 
 [testenv:docs]
-deps=
-    sphinx
-    sphinx_rtd_theme
-changedir=docs
+changedir = docs
 commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 


### PR DESCRIPTION
Extensions for arrow, delorean, and pendulum are available through `bloop.ext.<module name>`, each exposing `DateTime` to replace the built-in.

By default, the built-in `DateTime` only speaks utc `datetime.datetime`.