### PR TITLE
Columns in base classes with the meta flag 'abstract' are now included in the derived class.

### DIFF
--- a/bloop/engine.py
+++ b/bloop/engine.py
@@ -24,6 +24,7 @@ from .signals import (
 )
 from .stream import Stream
 from .util import missing, unpack_from_dynamodb, walk_subclasses
+from .type_engine import TypeEngine
 
 
 __all__ = ["Engine"]
@@ -97,7 +98,7 @@ class Engine:
     def __init__(self, *, dynamodb=None, dynamodbstreams=None):
         # Unique namespace so the type engine for multiple bloop Engines
         # won't have the same TypeDefinitions
-        self.type_engine = declare.TypeEngine.unique()
+        self.type_engine = TypeEngine.unique()
         self.session = SessionWrapper(dynamodb=dynamodb, dynamodbstreams=dynamodbstreams)
 
     def _dump(self, model, obj, context=None, **kwargs):

--- a/bloop/type_engine.py
+++ b/bloop/type_engine.py
@@ -1,0 +1,84 @@
+import inspect
+import uuid
+
+from declare import DeclareException, TypeEngine as TE
+
+
+class TypeEngine(TE):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def unique(cls):
+        """Return a unique type engine (using uuid4)"""
+        namespace = str(uuid.uuid4())
+        return TypeEngine(namespace)
+
+    def _get_typedef_name(self, typedef):
+        if not inspect.isclass(typedef):
+            _class = typedef.__class__
+        else:
+            _class = typedef
+        return _class.__name__
+
+    def clear(self):
+        self.bound_types.clear()
+        self.unbound_types.clear()
+
+    def register(self, typedef):
+        if self._get_typedef_name(typedef) in self.bound_types:
+            return
+        if not self.is_compatible(typedef):
+            raise ValueError("Incompatible type {} for engine {}".format(typedef, self))
+
+        # Unbound is a list of instances of the class
+        if typedef not in self.unbound_types:
+            self.unbound_types.add(typedef)
+            typedef._register(self)
+
+    def bind(self, **config):
+        while self.unbound_types:
+            typedef = self.unbound_types.pop()
+            try:
+                load, dump = typedef.bind(self, **config)
+                self.bound_types[self._get_typedef_name(typedef)] = {
+                    "load": load, "dump": dump
+                }
+            except Exception:
+                self.unbound_types.add(typedef)
+                raise
+
+    def load(self, typedef, value, **kwargs):
+        try:
+            bound_type = self.bound_types[self._get_typedef_name(typedef)]
+        except KeyError:
+            raise DeclareException(
+                "Can't load unknown type {}".format(typedef))
+        else:
+            # Don't need to try/catch since load/dump are bound together
+            return bound_type["load"](value, **kwargs)
+
+    def dump(self, typedef, value, **kwargs):
+        try:
+            bound_type = self.bound_types[self._get_typedef_name(typedef)]
+        except KeyError:
+            raise DeclareException(
+                "Can't dump unknown type {}".format(typedef))
+        else:
+            # Don't need to try/catch since load/dump are bound together
+            return bound_type["dump"](value, **kwargs)
+
+    def is_compatible(self, typedef):  # pragma: no cover
+        """
+        Returns ``true`` if the typedef is compatible with this engine.
+
+        This function should return ``False`` otherwise.  The default
+        implementation will always return ``True``.
+
+        """
+        return True
+
+    def __contains__(self, typedef):
+        return self._get_typedef_name(typedef) in self.bound_types
+

--- a/tests/helpers/models.py
+++ b/tests/helpers/models.py
@@ -12,6 +12,7 @@ from bloop import (
     Number,
     Set,
     String,
+    Boolean
 )
 
 
@@ -26,6 +27,18 @@ DocumentType = Map(**{
     'Id': UUID,
     'Updated': DateTime
 })
+
+
+class AbstractBaseClass(BaseModel):
+    class Meta:
+        abstract = True
+
+    id = Column(Integer, hash_key=True)
+    created = Column(DateTime, range_key=True)
+    modified = Column(DateTime)
+    active = Column(Boolean)
+    email = Column(String)
+    by_email = GlobalSecondaryIndex(hash_key="email", projection="all")
 
 
 class Document(BaseModel):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -2,7 +2,6 @@ import datetime
 import decimal
 import uuid
 
-import declare
 import pytest
 
 from bloop.types import (
@@ -20,6 +19,7 @@ from bloop.types import (
 )
 
 from ..helpers.models import DocumentType
+from bloop.type_engine import TypeEngine
 
 
 def symmetric_test(typedef, *pairs):
@@ -221,16 +221,16 @@ def test_set_illegal_backing_type():
 
 def test_set_registered():
     """set registers its typedef so loading/dumping happens properly"""
-    type_engine = declare.TypeEngine.unique()
+    type_engine = TypeEngine.unique()
     string_type = String()
     string_set_type = Set(string_type)
 
     type_engine.bind()
-    assert string_type not in type_engine.bound_types
+    assert 'String' not in type_engine.bound_types
 
     type_engine.register(string_set_type)
     type_engine.bind()
-    assert string_type in type_engine.bound_types
+    assert 'String' in type_engine.bound_types
 
 
 @pytest.mark.parametrize("value", [1, True, object(), bool, "str", False, 0, set(), ""], ids=repr)


### PR DESCRIPTION
This PR enables having `Columns` in base classes as long as there is a `Meta` class and the flag `abstract` is set to `True`.

I've added test cases where I thought it was appropriate, but let me know if I missed anything.

I'll add documentation once you guys let me know if this is useful to you.