### PR TITLE
Provisioned iops refactor

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,5 @@
+python:
+  setup_py_install: true
+  version: 3.5
+
+requirements_file: requirements.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,10 +13,6 @@ __ https://gist.github.com/numberoverzero/c5d0fc6dea624533d004239a27e545ad
  [Unreleased]
 --------------
 
---------------------
- 1.2.0 - 2017-09-10
---------------------
-
 Changed
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ __ https://gist.github.com/numberoverzero/c5d0fc6dea624533d004239a27e545ad
  [Unreleased]
 --------------
 
+--------------------
+ 1.2.0 - 2017-09-10
+--------------------
+
 Changed
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,27 @@ __ https://gist.github.com/numberoverzero/c5d0fc6dea624533d004239a27e545ad
  [Unreleased]
 --------------
 
+Changed
+=======
+
+* When a Model's Meta does not explicitly set ``read_units`` and ``write_units``, it will only default to 1/1 if the
+  table does not exist and needs to be created.  If the table already exists, any throughput will be considered
+  valid.  This will still ensure new tables have 1/1 iops as a default, but won't fail if an existing table has more
+  than one of either.
+
+  There is no behavior change for explicit **integer** values of ``read_units`` and ``write_units``: if the table does
+  not exist it will be created with those values, and if it does exist then validation will fail if the actual values
+  differ from the modeled values.
+
+  An explicit ``None`` for either ``read_units`` or ``write_units`` is equivalent to omitting the value, but allows
+  for a more explicit declaration in the model.
+
+  Because this is a relaxing of a default only within the context of validation (creation has the same semantics) the
+  only users that should be impacted are those that do not declare ``read_units`` and ``write_units`` and rely on the
+  built-in validation **failing** to match on values != 1.  Users that rely on the validation to succeed on tables with
+  values of 1 will see no change in behavior.  This fits within the extended criteria of a minor release since there
+  is a viable and obvious workaround for the current behavior (declare 1/1 and ensure failure on other values).
+
 --------------------
  1.1.0 - 2017-04-26
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,19 @@ Changed
   values of 1 will see no change in behavior.  This fits within the extended criteria of a minor release since there
   is a viable and obvious workaround for the current behavior (declare 1/1 and ensure failure on other values).
 
+* When a Query or Scan has projection type "count", accessing the ``count`` or ``scanned`` properties will
+  immediately execute and exhaust the iterator to provide the count or scanned count.  This simplifies the previous
+  workaround of calling ``next(query, None)`` before using ``query.count``.
+
+Fixed
+=====
+
+* Fixed a bug where a Query or Scan with projection "count" would always raise KeyError (see `Issue #95`_)
+* Fixed a bug where resetting a Query or Scan would cause ``__next__``
+  to raise ``botocore.exceptions.ParamValidationError`` (see `Issue #95`_)
+
+.. _Issue #95: https://github.com/numberoverzero/bloop/issues/95
+
 --------------------
  1.1.0 - 2017-04-26
 --------------------

--- a/bloop/__init__.py
+++ b/bloop/__init__.py
@@ -54,4 +54,4 @@ __all__ = [
     # Misc
     "Condition", "QueryIterator", "ScanIterator", "Stream"
 ]
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/bloop/conditions.py
+++ b/bloop/conditions.py
@@ -440,10 +440,10 @@ class BaseCondition:
             return other
         # (a & b) & (c & d) -> (a & b & c & d)
         elif self.operation == other.operation == "and":
-            return AndCondition(*(self.values + other.values))
+            return AndCondition(*self.values, *other.values)
         # (a & b) & (c > 2) -> (a & b & (c > 2))
         elif self.operation == "and":
-            return AndCondition(*(self.values + [other]))
+            return AndCondition(*self.values, other)
         # (a > 2) & (b & c) -> ((a > 2) & b & c)
         elif other.operation == "and":
             return AndCondition(self, *other.values)
@@ -484,10 +484,10 @@ class BaseCondition:
             return other
         # (a | b) | (c | d) -> (a | b | c | d)
         elif self.operation == other.operation == "or":
-            return OrCondition(*(self.values + other.values))
+            return OrCondition(*self.values, *other.values)
         # (a | b) | (c > 2) -> (a | b | (c > 2))
         elif self.operation == "or":
-            return OrCondition(*(self.values + [other]))
+            return OrCondition(*self.values, other)
         # (a > 2) | (b | c) -> ((a > 2) | b | c)
         elif other.operation == "or":
             return OrCondition(self, *other.values)

--- a/bloop/engine.py
+++ b/bloop/engine.py
@@ -151,12 +151,11 @@ class Engine:
         objs = set(objs)
         validate_not_abstract(*objs)
         for obj in objs:
-            item = {
+            self.session.delete_item({
                 "TableName": obj.Meta.table_name,
-                "Key": dump_key(self, obj)
-            }
-            item.update(render(self, obj=obj, atomic=atomic, condition=condition))
-            self.session.delete_item(item)
+                "Key": dump_key(self, obj),
+                **render(self, obj=obj, atomic=atomic, condition=condition)
+            })
             object_deleted.send(self, engine=self, obj=obj)
 
     def load(self, *objs, consistent=False):
@@ -251,12 +250,11 @@ class Engine:
         objs = set(objs)
         validate_not_abstract(*objs)
         for obj in objs:
-            item = {
+            self.session.save_item({
                 "TableName": obj.Meta.table_name,
                 "Key": dump_key(self, obj),
-            }
-            item.update(render(self, obj=obj, atomic=atomic, condition=condition, update=True))
-            self.session.save_item(item)
+                **render(self, obj=obj, atomic=atomic, condition=condition, update=True)
+            })
             object_saved.send(self, engine=self, obj=obj)
 
     def scan(self, model_or_index, filter=None, projection="all", consistent=False, parallel=None):

--- a/bloop/models.py
+++ b/bloop/models.py
@@ -390,7 +390,11 @@ class GlobalSecondaryIndex(Index):
 
     .. _GlobalSecondaryIndex: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html
     """
-    def __init__(self, *, projection, hash_key, range_key=None, read_units=None, write_units=None, name=None, **kwargs):
+    def __init__(
+            self, *, projection,
+            hash_key, range_key=None,
+            read_units=None, write_units=None,
+            name=None, **kwargs):
         super().__init__(hash_key=hash_key, range_key=range_key, name=name, projection=projection, **kwargs)
         self.write_units = write_units
         self.read_units = read_units

--- a/bloop/models.py
+++ b/bloop/models.py
@@ -1,4 +1,5 @@
 import collections.abc
+import logging
 
 import declare
 
@@ -9,6 +10,7 @@ from .util import missing, unpack_from_dynamodb
 
 
 __all__ = ["BaseModel", "Column", "GlobalSecondaryIndex", "LocalSecondaryIndex"]
+logger = logging.getLogger("bloop.models")
 
 
 def loaded_columns(obj):
@@ -90,6 +92,7 @@ class ModelMetaclass(declare.ModelMetaclass):
             # hash function has priority over the default.
             # If there aren't any bases with explicit hash functions,
             # just use object.__hash__
+            logger.info("searching for nearest __hash__ impl in {}.__mro__".format(name))
             for base in bases:
                 hash_fn = getattr(base, "__hash__")
                 if hash_fn:

--- a/bloop/models.py
+++ b/bloop/models.py
@@ -105,8 +105,8 @@ class ModelMetaclass(declare.ModelMetaclass):
         # new_class will set abstract to true, all other models are assumed
         # to be concrete unless specified
         setdefault(meta, "abstract", False)
-        setdefault(meta, "write_units", 1)
-        setdefault(meta, "read_units", 1)
+        setdefault(meta, "write_units", None)
+        setdefault(meta, "read_units", None)
 
         setup_columns(meta)
         setup_indexes(meta)
@@ -380,13 +380,17 @@ class GlobalSecondaryIndex(Index):
         Included columns will be projected into the index.  Key columns are always included.
     :param hash_key: The column that the index can be queried against.
     :param range_key: *(Optional)* The column that the index can be sorted on.  Default is None.
-    :param int read_units: *(Optional)* Provisioned read units for the index.  Default is 1.
-    :param int write_units:  *(Optional)* Provisioned write units for the index.  Default is 1.
+    :param int read_units: *(Optional)* Provisioned read units for the index.  Default is None.
+        When no value is provided and the index does not exist, it will be created with 1 read unit.  If the index
+        already exists, it will use the actual index's read units.
+    :param int write_units:  *(Optional)* Provisioned write units for the index.  Default is None.
+        When no value is provided and the index does not exist, it will be created with 1 write unit.  If the index
+        already exists, it will use the actual index's write units.
     :param str name: *(Optional)* The index's name in in DynamoDB. Defaults to the index’s name in the model.
 
     .. _GlobalSecondaryIndex: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html
     """
-    def __init__(self, *, projection, hash_key, range_key=None, read_units=1, write_units=1, name=None, **kwargs):
+    def __init__(self, *, projection, hash_key, range_key=None, read_units=None, write_units=None, name=None, **kwargs):
         super().__init__(hash_key=hash_key, range_key=range_key, name=name, projection=projection, **kwargs)
         self.write_units = write_units
         self.read_units = read_units

--- a/bloop/search.py
+++ b/bloop/search.py
@@ -420,7 +420,7 @@ class SearchIterator:
             self.scanned += response["ScannedCount"]
 
             # Each item is a dict of attributes
-            self.buffer.extend(response["Items"])
+            self.buffer.extend(response.get("Items", []))
 
         if self.buffer:
             return self.buffer.popleft()

--- a/bloop/search.py
+++ b/bloop/search.py
@@ -398,6 +398,7 @@ class SearchIterator:
         self.count = 0
         self.scanned = 0
         self._exhausted = False
+        self.request.pop("ExclusiveStartKey", None)
 
     @property
     def exhausted(self):

--- a/bloop/search.py
+++ b/bloop/search.py
@@ -359,13 +359,25 @@ class SearchIterator:
 
         self.buffer = collections.deque()
 
-        self.count = 0
-        """Number of items that have been loaded from DynamoDB so far, including buffered items."""
-
-        self.scanned = 0
-        """Number of items that DynamoDB evaluated, before any filter was applied."""
-
+        self._count = 0
+        self._scanned = 0
         self._exhausted = False
+
+    @property
+    def count(self):
+        """Number of items that have been loaded from DynamoDB so far, including buffered items."""
+        if self.request["Select"] == "COUNT":
+            while not self.exhausted:
+                next(self, None)
+        return self._count
+
+    @property
+    def scanned(self):
+        """Number of items that DynamoDB evaluated, before any filter was applied."""
+        if self.request["Select"] == "COUNT":
+            while not self.exhausted:
+                next(self, None)
+        return self._scanned
 
     def first(self):
         """Return the first result.  If there are no results, raises :exc:`~bloop.exceptions.ConstraintViolation`.
@@ -395,8 +407,8 @@ class SearchIterator:
     def reset(self):
         """Reset to the initial state, clearing the buffer and zeroing count and scanned."""
         self.buffer.clear()
-        self.count = 0
-        self.scanned = 0
+        self._count = 0
+        self._scanned = 0
         self._exhausted = False
         self.request.pop("ExclusiveStartKey", None)
 
@@ -417,8 +429,8 @@ class SearchIterator:
             continuation_token = self.request["ExclusiveStartKey"] = response.get("LastEvaluatedKey", None)
             self._exhausted = not continuation_token
 
-            self.count += response["Count"]
-            self.scanned += response["ScannedCount"]
+            self._count += response["Count"]
+            self._scanned += response["ScannedCount"]
 
             # Each item is a dict of attributes
             self.buffer.extend(response.get("Items", []))

--- a/bloop/types.py
+++ b/bloop/types.py
@@ -15,13 +15,10 @@ BOOLEAN = "BOOL"
 MAP = "M"
 LIST = "L"
 
-PRIMITIVES = ["S", "N", "B"]
-SETS = ["SS", "NS", "BS"]
-DOCUMENTS = ["L", "M"]
-# TODO | revert this commit when RTD gets 3.5 support, because getting conda to work with autodoc was
-# TODO | atrocious.  It's actually easier to go through and drop all the nice 3.5 syntax than lose
-# TODO | another 4 hours fucking around with RTD's build settings and a bunch of .yml files.
-ALL = PRIMITIVES + SETS + DOCUMENTS + [BOOLEAN]
+PRIMITIVES = {"S", "N", "B"}
+SETS = {"SS", "NS", "BS"}
+DOCUMENTS = {"L", "M"}
+ALL = {*PRIMITIVES, *SETS, *DOCUMENTS, BOOLEAN}
 
 # Dynamo takes numbers as strings to reduce inter-language problems
 DYNAMODB_CONTEXT = decimal.Context(
@@ -39,9 +36,9 @@ SUPPORTED_OPERATIONS = {
     ">": PRIMITIVES,
     "<=": PRIMITIVES,
     ">=": PRIMITIVES,
-    "begins_with": [STRING, BINARY],
+    "begins_with": {STRING, BINARY},
     "between": PRIMITIVES,
-    "contains": SETS + [STRING, BINARY, LIST],
+    "contains": {*SETS, STRING, BINARY, LIST},
     "in": ALL
 }
 

--- a/docs/_static/bloop.css
+++ b/docs/_static/bloop.css
@@ -5,3 +5,7 @@
 .wy-menu-vertical p.caption {
     font-size: 90%;
 }
+
+.versionmodified {
+    font-style: italic
+}

--- a/docs/api/internal.rst
+++ b/docs/api/internal.rst
@@ -105,6 +105,7 @@ SearchModelIterator
     .. attribute:: count
 
         Number of items that have been loaded from DynamoDB so far, including buffered items.
+        When projection type is "count", accessing this will automatically exhaust the query.
 
     .. attribute:: exhausted
 
@@ -126,6 +127,7 @@ SearchModelIterator
     .. attribute:: scanned
 
         Number of items that DynamoDB evaluated, before any filter was applied.
+        When projection type is "count", accessing this will automatically exhaust the query.
 
 =========
 Streaming

--- a/docs/api/public.rst
+++ b/docs/api/public.rst
@@ -470,6 +470,7 @@ You should use :class:`decimal.Decimal` instances to avoid rounding errors:
     .. attribute:: count
 
         Number of items that have been loaded from DynamoDB so far, including buffered items.
+        When projection type is "count", accessing this will automatically exhaust the query.
 
     .. attribute:: exhausted
 
@@ -491,6 +492,7 @@ You should use :class:`decimal.Decimal` instances to avoid rounding errors:
     .. attribute:: scanned
 
         Number of items that DynamoDB evaluated, before any filter was applied.
+        When projection type is "count", accessing this will automatically exhaust the query.
 
 ======
  Scan
@@ -501,6 +503,7 @@ You should use :class:`decimal.Decimal` instances to avoid rounding errors:
     .. attribute:: count
 
         Number of items that have been loaded from DynamoDB so far, including buffered items.
+        When projection type is "count", accessing this will automatically exhaust the query.
 
     .. attribute:: exhausted
 
@@ -522,6 +525,7 @@ You should use :class:`decimal.Decimal` instances to avoid rounding errors:
     .. attribute:: scanned
 
         Number of items that DynamoDB evaluated, before any filter was applied.
+        When projection type is "count", accessing this will automatically exhaust the query.
 
 ========
  Stream

--- a/docs/user/conditions.rst
+++ b/docs/user/conditions.rst
@@ -233,9 +233,9 @@ The following condition is used:
         (Document.name == ".bashrc")
     )
 
-There's no way to know if the previous value for eg. ``folder`` had a value, since the scan told DynamoDB not to
-include that column when it performed the scan.  There's no save assumption for the state of that column in DynamoDB,
-so it's not part of the generated atomic condition.
+There's no way to know if the existing row in DynamoDB had a value for eg. ``folder``, since the scan told DynamoDB
+not to include that column when it performed the scan.  There's no save assumption for the state of that column
+in DynamoDB, so it's not part of the generated atomic condition.
 
 --------------------------------
  Example: Query on a Projection
@@ -274,8 +274,8 @@ The atomic condition used for this object will be:
         Document.size.is_(None)
     )
 
-If the value in DynamoDB has a value for ``size``, the operation will fail.  If the document's ``data`` column has
-changed since the query executed, this atomic condition won't care.
+If the existing row in DynamoDB has a value for ``size``, the operation will fail.  If the document's ``data``
+column has changed since the query executed, this atomic condition won't care.
 
 -------------------------
  Example: Save then Save

--- a/docs/user/engine.rst
+++ b/docs/user/engine.rst
@@ -258,6 +258,34 @@ Similar to :func:`~bloop.search.QueryIterator.first`, you can get the unique res
         ...
     ConstraintViolation: Query found more than one result.
 
+-------
+ Count
+-------
+
+To get a count of items that match some query use the ``"count"`` projection.
+
+.. code-block:: pycon
+
+    >>> q = engine.query(
+    ...         Account.by_email,
+    ...         key=Account.email == "foo@bar.com",
+    ...         projection="count")
+    >>> q.count
+    256
+
+Both ``count`` and ``scanned`` are calculated only when the query is executed, so you must call
+:func:`QueryIterator.reset` to see changes take effect.
+
+.. code-block:: pycon
+
+    >>> new = Account(...)
+    >>> engine.save(new)
+    >>> q.count
+    256
+    >>> q.reset()
+    >>> q.count
+    257
+
 .. _user-query-key:
 
 ----------------
@@ -338,8 +366,7 @@ Here is the same LSI query as above, but now excluding accounts created in the l
 
 By default, queries return all columns projected into the index or model.  You can use the ``projection`` parameter
 to control which columns are returned for each object.  This must be "all" to include everything in the index or
-model's projection, or a list of columns or column model names to include.  Use "count" to get the number of results
-that match the query.
+model's projection, or a list of columns or column model names to include.
 
 .. code-block:: pycon
 

--- a/docs/user/engine.rst
+++ b/docs/user/engine.rst
@@ -144,7 +144,7 @@ form a single ConditionExpression.
 ========
 
 :func:`Delete <bloop.engine.Engine.delete>` has the same signature as :func:`~bloop.engine.Engine.save`.  Both
-operations are mutations on an object that may or may not exist, and simply map to two different apis (Delete calls
+operations are mutations on an object that may or may not exist, and simply map to two different APIs (Delete calls
 `DeleteItem`_).  You can delete multiple objects at once, specify a ``condition``, and use the ``atomic=True``
 shorthand to only delete objects unchanged since you last loaded them from DynamoDB.
 

--- a/docs/user/extensions.rst
+++ b/docs/user/extensions.rst
@@ -1,7 +1,7 @@
 Bloop Extensions
 ^^^^^^^^^^^^^^^^
 
-Extensions' dependencies aren't installed with Bloop, because they may include a huge number of libraries that Bloop
+Extension dependencies aren't installed with Bloop, because they may include a huge number of libraries that Bloop
 does not depend on.  For example, two extensions could provide automatic mapping to Django or SQLAlchemy models.
 Many users would never need either of these, since Bloop does not depend on them for normal usage.
 

--- a/docs/user/patterns.rst
+++ b/docs/user/patterns.rst
@@ -290,8 +290,8 @@ uses flask and marshmallow to expose get and list operations for a User class:
             fields += [column.model_name for column in User.Meta.columns]
         # Smart hyperlinking
         _links = ma.Hyperlinks({
-            'self': ma.URLFor('author_detail', id='<id>'),
-            'collection': ma.URLFor('authors')
+            'self': ma.URLFor('user_detail', id='<id>'),
+            'collection': ma.URLFor('users')
         })
 
     user_schema = UserSchema()

--- a/docs/user/streams.rst
+++ b/docs/user/streams.rst
@@ -167,6 +167,8 @@ The second record shows the change to email, and has both old and new objects:
          'sequence_number': '800000000007366876936'}
     }
 
+.. _periodic-heartbeats:
+
 -------------------
 Periodic Heartbeats
 -------------------

--- a/docs/user/types.rst
+++ b/docs/user/types.rst
@@ -429,3 +429,40 @@ To instead store enums as their integer values, we can modify the enum class abo
                 return value
             value = super().dynamo_load(value, context=context, **kwargs)
             return self.enum_cls(value)
+
+.. _type-validation:
+
+=================
+ Type Validation
+=================
+
+By default Bloop does not verify that each model's values have the correct types.  For example, consider this model:
+
+.. code-block:: python
+
+    class Appointment(BaseModel):
+        id = Column(UUID, hash_key=True)
+        date = Column(DateTime)
+        location = Column(String)
+
+
+The following code won't throw type errors until we try to persist to DynamoDB:
+
+.. code-block:: pycon
+
+    >>> engine.bind(Appointment)
+    >>> a = Appointment(id="not-a-uuid")
+    >>> a.location = 421
+    >>> a
+    Appointment(id='not-a-uuid', location=421)
+
+    >>> engine.save(a)
+    ParamValidationError: ...
+
+This is because Bloop is designed to be maximally customizable, and easily extend your existing object model framework.
+There's also no built-in way to specify that a column is non-nullable.  For an example of adding both these constraints
+to your :class:`~bloop.models.Column`, see :ref:`custom-column`.  Alternatively, consider a more robust option such as
+the exceptional `marshmallow`__.  An example integrating with marshmallow and flask is
+:ref:`available here <marshmallow-pattern>`.
+
+__ https://marshmallow.readthedocs.io

--- a/requirements-to-freeze.txt
+++ b/requirements-to-freeze.txt
@@ -7,6 +7,7 @@ delorean
 flake8
 pendulum
 pytest
+pytest-catchlog
 sphinx
 sphinx-rtd-theme
 tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ delorean==0.6.0
 flake8==3.3.0
 pendulum==1.2.0
 pytest==3.0.7
+pytest-catchlog==1.2.2
 sphinx==1.5.5
 sphinx-rtd-theme==0.2.4
 tox==2.7.0

--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -5,6 +5,7 @@ import string
 import blinker
 import boto3
 import pytest
+
 from bloop import Engine
 from bloop.signals import model_created
 

--- a/tests/integ/test_basic.py
+++ b/tests/integ/test_basic.py
@@ -106,3 +106,26 @@ def test_model_overlap(dynamodb, engine):
     engine.bind(FirstOverlap)
     engine.bind(SecondOverlap)
     assert True
+
+
+def test_unknown_throughput(dynamodb, engine):
+    """A model doesn't have to specify read_units or write_units but will take the existing value"""
+    class ExplicitValues(BaseModel):
+        class Meta:
+            read_units = 10
+            write_units = 1
+            table_name = "throughput-test"
+        id = Column(Integer, hash_key=True)
+
+    class ImplicitValues(BaseModel):
+        class Meta:
+            write_units = 1
+            table_name = "throughput-test"
+        id = Column(Integer, hash_key=True)
+
+    engine.bind(ExplicitValues)
+    assert ImplicitValues.Meta.read_units is None
+
+    # Now binding to the same table but not specifying read_units should have the same value
+    engine.bind(ImplicitValues)
+    assert ImplicitValues.Meta.read_units == 10

--- a/tests/integ/test_basic.py
+++ b/tests/integ/test_basic.py
@@ -116,16 +116,24 @@ def test_unknown_throughput(dynamodb, engine):
             write_units = 1
             table_name = "throughput-test"
         id = Column(Integer, hash_key=True)
+        other = Column(Integer)
+        by_other = GlobalSecondaryIndex(
+            projection="keys", hash_key=other, read_units=11, write_units=1)
 
     class ImplicitValues(BaseModel):
         class Meta:
             write_units = 1
             table_name = "throughput-test"
         id = Column(Integer, hash_key=True)
+        other = Column(Integer)
+        by_other = GlobalSecondaryIndex(
+            projection="keys", hash_key=other, write_units=1)
 
     engine.bind(ExplicitValues)
     assert ImplicitValues.Meta.read_units is None
+    assert ImplicitValues.by_other.read_units is None
 
     # Now binding to the same table but not specifying read_units should have the same value
     engine.bind(ImplicitValues)
     assert ImplicitValues.Meta.read_units == 10
+    assert ImplicitValues.by_other.read_units == 11

--- a/tests/integ/test_basic.py
+++ b/tests/integ/test_basic.py
@@ -1,5 +1,6 @@
 """Basic scenarios, symmetric tests"""
 import pytest
+
 from bloop import (
     BaseModel,
     Column,

--- a/tests/integ/test_queries.py
+++ b/tests/integ/test_queries.py
@@ -14,3 +14,16 @@ def test_query_with_projection(engine):
 
     result = query.one()
     assert not hasattr(result, "profile")
+
+
+def test_scan_count(engine):
+    engine.bind(User)
+    for _ in range(7):
+        engine.save(valid_user())
+    scan = engine.scan(User, projection="count")
+    assert scan.count == 0
+    try:
+        next(scan)
+    except StopIteration:
+        pass
+    assert scan.count == 7

--- a/tests/integ/test_queries.py
+++ b/tests/integ/test_queries.py
@@ -18,12 +18,12 @@ def test_query_with_projection(engine):
 
 def test_scan_count(engine):
     engine.bind(User)
+    scan = engine.scan(User, projection="count")
+
     for _ in range(7):
         engine.save(valid_user())
-    scan = engine.scan(User, projection="count")
-    assert scan.count == 0
-    try:
-        next(scan)
-    except StopIteration:
-        pass
     assert scan.count == 7
+
+    scan.reset()
+    engine.save(valid_user())
+    assert scan.count == 8

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+
 from bloop import BaseModel, Engine
 from bloop.session import SessionWrapper
 from bloop.signals import (

--- a/tests/unit/test_conditions.py
+++ b/tests/unit/test_conditions.py
@@ -1,6 +1,7 @@
 import operator
 
 import pytest
+
 from bloop.conditions import (
     AndCondition,
     BaseCondition,

--- a/tests/unit/test_conditions.py
+++ b/tests/unit/test_conditions.py
@@ -1,3 +1,4 @@
+import logging
 import operator
 
 import pytest
@@ -514,7 +515,7 @@ def test_render_missing_object(engine):
     ("key", "KeyConditionExpression"),
     ("condition", "ConditionExpression"),
 ])
-def test_render_condition_only(kwarg_name, expression_key, engine):
+def test_render_condition_only(kwarg_name, expression_key, engine, caplog):
     """Only renders the given condition"""
     condition = (User.email == "@") & (User.name.is_(None))
     rendered = render(engine, **{kwarg_name: condition})
@@ -523,6 +524,11 @@ def test_render_condition_only(kwarg_name, expression_key, engine):
         "ExpressionAttributeValues": {":v1": {"S": "@"}},
         expression_key: "((#n0 = :v1) AND (attribute_not_exists(#n2)))"
     }
+
+    assert caplog.record_tuples == [
+        ("bloop.conditions", logging.DEBUG, "popping last usage of Reference(name=':v3', type='value', value=None)"),
+        ("bloop.conditions", logging.DEBUG, "rendering \"==\" as attribute_not_exists"),
+    ]
 
 
 def test_render_projection_only(engine):

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -333,9 +333,7 @@ def test_save_list_with_condition(engine, session, caplog):
         session.save_item.assert_any_call(expected)
     assert session.save_item.call_count == 3
 
-    assert caplog.record_tuples == [
-        ("bloop.engine", logging.INFO, "successfully saved 3 objects")
-    ]
+    assert caplog.record_tuples[-1] == ("bloop.engine", logging.INFO, "successfully saved 3 objects")
 
 
 def test_save_single_with_condition(engine, session):
@@ -451,9 +449,7 @@ def test_delete_multiple_condition(engine, session, caplog):
         session.delete_item.assert_any_call(expected)
     assert session.delete_item.call_count == 3
 
-    assert caplog.record_tuples == [
-        ("bloop.engine", logging.INFO, "successfully deleted 3 objects")
-    ]
+    assert caplog.record_tuples[-1] == ("bloop.engine", logging.INFO, "successfully deleted 3 objects")
 
 
 def test_delete_atomic(engine, session):
@@ -588,6 +584,7 @@ def test_bind_skip_abstract_models(engine, session, caplog):
     class AlsoConcrete(AlsoAbstract):
         id = Column(Integer, hash_key=True)
 
+    caplog.handler.records.clear()
     engine.bind(Abstract)
 
     session.create_table.assert_any_call(Concrete)

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from unittest.mock import Mock
 
 import pytest
@@ -21,7 +22,7 @@ from bloop.util import ordered
 from ..helpers.models import ComplexModel, User, VectorModel
 
 
-def test_missing_objects(engine, session):
+def test_missing_objects(engine, session, caplog):
     """When objects aren't loaded, MissingObjects is raised with a list of missing objects"""
     # Patch batch_get_items to return no results
     session.load_items.return_value = {}
@@ -31,6 +32,10 @@ def test_missing_objects(engine, session):
     with pytest.raises(MissingObjects) as excinfo:
         engine.load(*users)
     assert set(excinfo.value.objects) == set(users)
+
+    assert caplog.record_tuples == [
+        ("bloop.engine", logging.WARNING, "loaded 0 of 3 objects")
+    ]
 
 
 def test_dump_key(engine):
@@ -156,7 +161,7 @@ def test_load_equivalent_objects(engine, session):
     assert same_user.name == "foo"
 
 
-def test_load_shared_table(engine, session):
+def test_load_shared_table(engine, session, caplog):
     """Two different models backed by the same table try to load the same hash key.
     They share the column "shared" but load the content differently
     """
@@ -194,6 +199,7 @@ def test_load_shared_table(engine, session):
     first = FirstModel(id=id, range=range)
     second = SecondModel(id=id, range=range)
 
+    caplog.handler.records.clear()
     engine.load(first, second)
 
     expected_first = FirstModel(id=id, range=range, first="first", as_date=now)
@@ -206,6 +212,10 @@ def test_load_shared_table(engine, session):
         assert getattr(second, attr, missing) == getattr(expected_second, attr, missing)
     assert not hasattr(first, "second")
     assert not hasattr(second, "first")
+
+    assert caplog.record_tuples == [
+        ("bloop.engine", logging.INFO, "successfully loaded 2 objects")
+    ]
 
 
 def test_load_missing_attrs(engine, session):
@@ -308,7 +318,7 @@ def test_save_twice(engine, session):
     assert session.save_item.call_count == 2
 
 
-def test_save_list_with_condition(engine, session):
+def test_save_list_with_condition(engine, session, caplog):
     users = [User(id=str(i)) for i in range(3)]
     condition = User.id.is_(None)
     expected_calls = [
@@ -322,6 +332,10 @@ def test_save_list_with_condition(engine, session):
     for expected in expected_calls:
         session.save_item.assert_any_call(expected)
     assert session.save_item.call_count == 3
+
+    assert caplog.record_tuples == [
+        ("bloop.engine", logging.INFO, "successfully saved 3 objects")
+    ]
 
 
 def test_save_single_with_condition(engine, session):
@@ -422,7 +436,7 @@ def test_save_del_only(engine, session):
     session.save_item.assert_called_once_with(expected)
 
 
-def test_delete_multiple_condition(engine, session):
+def test_delete_multiple_condition(engine, session, caplog):
     users = [User(id=str(i)) for i in range(3)]
     condition = User.id == "foo"
     expected_calls = [
@@ -436,6 +450,10 @@ def test_delete_multiple_condition(engine, session):
     for expected in expected_calls:
         session.delete_item.assert_any_call(expected)
     assert session.delete_item.call_count == 3
+
+    assert caplog.record_tuples == [
+        ("bloop.engine", logging.INFO, "successfully deleted 3 objects")
+    ]
 
 
 def test_delete_atomic(engine, session):
@@ -553,7 +571,7 @@ def test_bind_non_model(engine):
         engine.bind(object())
 
 
-def test_bind_skip_abstract_models(engine, session):
+def test_bind_skip_abstract_models(engine, session, caplog):
     class Abstract(BaseModel):
         class Meta:
             abstract = True
@@ -576,6 +594,11 @@ def test_bind_skip_abstract_models(engine, session):
     session.validate_table.assert_any_call(Concrete)
     session.create_table.assert_any_call(AlsoConcrete)
     session.validate_table.assert_any_call(AlsoConcrete)
+
+    assert caplog.record_tuples == [
+        ("bloop.engine", logging.DEBUG, "binding non-abstract models ['AlsoConcrete', 'Concrete']"),
+        ("bloop.engine", logging.INFO, "successfully bound 2 models to the engine"),
+    ]
 
 
 def test_bind_concrete_base(engine, session):
@@ -614,7 +637,7 @@ def test_bind_different_engines(dynamodb, dynamodbstreams):
     assert Concrete in second_engine.type_engine.bound_types
 
 
-def test_bind_skip_table_setup(dynamodb, dynamodbstreams):
+def test_bind_skip_table_setup(dynamodb, dynamodbstreams, caplog):
     # Required so engine doesn't pass boto3 to the wrapper
     engine = Engine(dynamodb=dynamodb, dynamodbstreams=dynamodbstreams)
     engine.session = Mock(spec=SessionWrapper)
@@ -622,6 +645,13 @@ def test_bind_skip_table_setup(dynamodb, dynamodbstreams):
     engine.bind(User, skip_table_setup=True)
     engine.session.create_table.assert_not_called()
     engine.session.validate_table.assert_not_called()
+
+    assert caplog.record_tuples == [
+        ("bloop.engine", logging.DEBUG, "binding non-abstract models ['Admin', 'User']"),
+        ("bloop.engine", logging.INFO,
+         "skip_table_setup is True; not trying to create tables or validate models during bind"),
+        ("bloop.engine", logging.INFO, "successfully bound 2 models to the engine"),
+    ]
 
 
 @pytest.mark.parametrize("op_name, plural", [("save", True), ("load", True), ("delete", True)], ids=str)

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -2,6 +2,7 @@ import datetime
 from unittest.mock import Mock
 
 import pytest
+
 from bloop.engine import Engine, dump_key
 from bloop.exceptions import (
     InvalidModel,

--- a/tests/unit/test_ext/test_arrow.py
+++ b/tests/unit/test_ext/test_arrow.py
@@ -1,10 +1,11 @@
-import pytest
-import arrow
-from bloop.types import FIXED_ISO8601_FORMAT
 from datetime import datetime
+
+import arrow
+import pytest
 import pytz
 
 from bloop.ext.arrow import DateTime
+from bloop.types import FIXED_ISO8601_FORMAT
 
 
 now = datetime.now(pytz.utc)

--- a/tests/unit/test_ext/test_delorean.py
+++ b/tests/unit/test_ext/test_delorean.py
@@ -1,10 +1,11 @@
-import pytest
-import delorean
-from bloop.types import FIXED_ISO8601_FORMAT
 from datetime import datetime
+
+import delorean
+import pytest
 import pytz
 
 from bloop.ext.delorean import DateTime
+from bloop.types import FIXED_ISO8601_FORMAT
 
 
 now = datetime.now(pytz.utc)

--- a/tests/unit/test_ext/test_pendulum.py
+++ b/tests/unit/test_ext/test_pendulum.py
@@ -1,10 +1,11 @@
-import pytest
-import pendulum
-from bloop.types import FIXED_ISO8601_FORMAT
 from datetime import datetime
+
+import pendulum
+import pytest
 import pytz
 
 from bloop.ext.pendulum import DateTime
+from bloop.types import FIXED_ISO8601_FORMAT
 
 
 now = datetime.now(pytz.utc)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,7 +1,8 @@
+import datetime
 import operator
 
-import datetime
 import pytest
+
 from bloop.conditions import ConditionRenderer
 from bloop.exceptions import InvalidIndex, InvalidModel, InvalidStream
 from bloop.models import (

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -112,12 +112,12 @@ def test_load_dump_none(engine):
 
 
 def test_meta_read_write_units():
-    """If `read_units` or `write_units` is missing from a model's Meta, it defaults to 1"""
+    """If `read_units` or `write_units` is missing from a model's Meta, it defaults to None until bound"""
     class Model(BaseModel):
         id = Column(UUID, hash_key=True)
 
-    assert Model.Meta.write_units == 1
-    assert Model.Meta.read_units == 1
+    assert Model.Meta.write_units is None
+    assert Model.Meta.read_units is None
 
     class Other(BaseModel):
         class Meta:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -640,6 +640,16 @@ def test_lsi_delegates_throughput():
     assert lsi.read_units == meta.read_units
 
 
+def test_gsi_default_throughput():
+    """When not specified, GSI read_units and write_units are None"""
+    class Model(BaseModel):
+        name = Column(String, hash_key=True)
+        other = Column(String)
+        by_joined = GlobalSecondaryIndex(hash_key="other", projection="keys")
+    gsi = Model.by_joined
+    assert gsi.read_units is gsi.write_units is None
+
+
 @pytest.mark.parametrize("projection", ["all", "keys", ["foo"]])
 def test_index_repr(projection):
     index = Index(projection=projection, name="f")

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import operator
 
 import pytest
@@ -378,7 +379,7 @@ def test_defined_hash():
     assert Model.__hash__ is hash_fn
 
 
-def test_parent_hash():
+def test_parent_hash(caplog):
     """Parent __hash__ function is used, not object __hash__"""
     class OtherBase:
         # Explicit __eq__ prevents OtherBase from having a __hash__
@@ -389,9 +390,13 @@ def test_parent_hash():
         def __hash__(self):
             return id(self)
 
-    class Model(OtherBase, BaseWithHash, BaseModel):
+    class MyModel(OtherBase, BaseWithHash, BaseModel):
         id = Column(Integer, hash_key=True)
-    assert Model.__hash__ is BaseWithHash.__hash__
+    assert MyModel.__hash__ is BaseWithHash.__hash__
+
+    assert caplog.record_tuples == [
+        ("bloop.models", logging.INFO, "searching for nearest __hash__ impl in MyModel.__mro__"),
+    ]
 
 
 # END BASE MODEL ======================================================================================= END BASE MODEL

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -272,7 +272,9 @@ def simple_iter(engine, session):
             "session": session,
             "model": model,
             "index": index,
-            "request": {},
+            "request": {
+                "Select": "SPECIFIC_ATTRIBUTES"
+            },
             "projected": set()
         }
         if issubclass(cls, SearchModelIterator):
@@ -666,23 +668,31 @@ def test_iterator_returns_self(simple_iter):
     assert iterator is iter(iterator)
 
 
-def test_iterator_reset(simple_iter):
+def test_iterator_reset(simple_iter, session):
     """reset clears buffer, count, scanned, exhausted"""
     iterator = simple_iter()
+    iterator.request["Select"] = "COUNT"
+
+    def reset_state():
+        # This helper is necessary because the .count and .scanned properties will
+        # exhaust the search pagination during a Select=COUNT query,
+        # so we must reset the mock responses each time
+        session.search_items.side_effect = build_responses([0, 1, 1], items=["a", "b"])
+        iterator.reset()
 
     # Pretend we've stepped the iterator a few times
-    iterator.count = 9
-    iterator.scanned = 12
+    iterator._count = 9
+    iterator._scanned = 12
     iterator.buffer.append("obj")
     iterator._exhausted = True
 
-    iterator.reset()
-
     # Ready to go again, buffer empty and counters reset
-    assert iterator.count == 0
-    assert iterator.scanned == 0
+    reset_state()
+    assert iterator.count == 2
+    reset_state()
+    assert iterator.scanned == 6
     assert len(iterator.buffer) == 0
-    assert not iterator.exhausted
+    assert iterator.exhausted
 
 
 @pytest.mark.parametrize("buffer_size", [0, 1])
@@ -791,6 +801,8 @@ def test_one_failure(simple_iter, session, chain):
     # SearchIterator.one should advance exactly twice, every time
     expected_calls = calls_for_current_steps(chain, 2)
     assert session.search_items.call_count == expected_calls
+    assert iterator.count == sum(chain)
+    assert iterator.scanned == 3 * sum(chain)
 
 
 @pytest.mark.parametrize("cls", [ScanIterator, QueryIterator])

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -2,6 +2,7 @@ import collections
 import functools
 
 import pytest
+
 from bloop.conditions import (
     AndCondition,
     BeginsWithCondition,

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 import botocore.exceptions
 import pytest
+
 from bloop.exceptions import (
     BloopException,
     ConstraintViolation,

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -516,6 +516,7 @@ def test_validate_unspecified_throughput(session, dynamodb, caplog):
 
     assert MyModel.Meta.read_units is None
     assert MyModel.Meta.write_units is None
+    caplog.handler.records.clear()
     session.validate_table(MyModel)
     assert MyModel.Meta.read_units == 15
     assert MyModel.Meta.write_units == 20
@@ -551,6 +552,7 @@ def test_validate_unspecified_gsi_throughput(session, dynamodb, caplog):
 
     assert MyModel.by_other.read_units is None
     assert MyModel.by_other.write_units is None
+    caplog.handler.records.clear()
     session.validate_table(MyModel)
     assert MyModel.by_other.read_units == 15
     assert MyModel.by_other.write_units == 20
@@ -590,6 +592,7 @@ def test_validate_stream_exists(session, dynamodb, caplog):
         "TableName": "MyModel",
         "TableStatus": "ACTIVE"}
     dynamodb.describe_table.return_value = {"Table": full}
+    caplog.handler.records.clear()
     session.validate_table(MyModel)
     assert MyModel.Meta.stream["arn"] == "table/stream_both/stream/2016-08-29T03:30:15.582"
 

--- a/tests/unit/test_stream/conftest.py
+++ b/tests/unit/test_stream/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 from bloop.stream.coordinator import Coordinator
 from bloop.stream.shard import Shard
 

--- a/tests/unit/test_stream/test_buffer.py
+++ b/tests/unit/test_stream/test_buffer.py
@@ -2,6 +2,7 @@ import datetime
 from unittest.mock import Mock
 
 import pytest
+
 from bloop.stream.buffer import RecordBuffer, heap_item
 from bloop.stream.shard import Shard
 

--- a/tests/unit/test_stream/test_coordinator.py
+++ b/tests/unit/test_stream/test_coordinator.py
@@ -1,6 +1,7 @@
 import collections
 import datetime
 import functools
+import logging
 from unittest.mock import call
 
 import pytest
@@ -303,7 +304,7 @@ def test_remove_shard(is_active, is_root, has_buffered, coordinator):
         assert record_shard is not shard
 
 
-def test_move_to_old_token(coordinator, shard, session):
+def test_move_to_old_token(coordinator, shard, session, caplog):
     """Can't rebuild from a token with shards that have no connection to the current generation"""
     root = Shard(stream_arn=coordinator.stream_arn, shard_id="parent-shard")
     shard.parent = root
@@ -318,8 +319,13 @@ def test_move_to_old_token(coordinator, shard, session):
     with pytest.raises(InvalidStream):
         coordinator.move_to(token)
 
+    assert caplog.record_tuples == [
+        ("bloop.stream", logging.INFO, "Unknown or expired shard \"parent-shard\" - pruning from stream token"),
+        ("bloop.stream", logging.INFO, "Unknown or expired shard \"shard-id\" - pruning from stream token"),
+    ]
 
-def test_move_to_valid_token(coordinator, session):
+
+def test_move_to_valid_token(coordinator, session, caplog):
     """Moving to a token validates and clears unknown shards, and gets iterators for active shards"""
     # +--------------+
     # | <TOKEN>      |       # 0: token root no longer exists; was active
@@ -357,7 +363,7 @@ def test_move_to_valid_token(coordinator, session):
     )
 
 
-def test_move_to_token_with_old_sequence_number(coordinator, session):
+def test_move_to_token_with_old_sequence_number(coordinator, session, caplog):
     """If a token shard's sequence_number is past the trim_horizon, it moves to trim_horizon."""
     description = stream_description(1)
     stream_arn = coordinator.stream_arn
@@ -387,6 +393,11 @@ def test_move_to_token_with_old_sequence_number(coordinator, session):
         call(stream_arn=stream_arn, shard_id=shard_id,
              sequence_number=None, iterator_type="trim_horizon")
     ])
+
+    assert caplog.record_tuples == [
+        ("bloop.stream", logging.INFO,
+         "SequenceNumber \"beyond-trim-horizon\" in shard \"shard-id-0\" beyond trim horizon: jumping to trim_horizon")
+    ]
 
 
 def test_move_to_future_time(coordinator, session):

--- a/tests/unit/test_stream/test_coordinator.py
+++ b/tests/unit/test_stream/test_coordinator.py
@@ -4,6 +4,7 @@ import functools
 from unittest.mock import call
 
 import pytest
+
 from bloop.exceptions import InvalidPosition, InvalidStream, RecordsExpired
 from bloop.stream.shard import CALLS_TO_REACH_HEAD, Shard, last_iterator
 from bloop.util import ordered

--- a/tests/unit/test_stream/test_shard.py
+++ b/tests/unit/test_stream/test_shard.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import random
 from unittest.mock import call
 
@@ -178,7 +179,7 @@ def test_exhausted(shard):
     assert not shard.exhausted
 
 
-def test_token():
+def test_token(caplog):
     parent = Shard(stream_arn="parent-stream-arn", shard_id="parent-id")
     shard = Shard(stream_arn="stream-arn", shard_id="shard-id",
                   iterator_id="iterator-id", iterator_type="at_sequence",
@@ -196,6 +197,13 @@ def test_token():
     shard.parent = None
     expected.pop("parent")
     assert shard.token == expected
+    assert not caplog.records
+
+    shard.iterator_type = "trim_horizon"
+    shard.token
+    assert caplog.record_tuples == [
+        ("bloop.stream", logging.WARNING, "creating shard token at non-exact location \"trim_horizon\"")
+    ]
 
 
 def test_walk_tree():

--- a/tests/unit/test_stream/test_shard.py
+++ b/tests/unit/test_stream/test_shard.py
@@ -3,6 +3,7 @@ import random
 from unittest.mock import call
 
 import pytest
+
 from bloop.exceptions import ShardIteratorExpired
 from bloop.stream.shard import (
     CALLS_TO_REACH_HEAD,

--- a/tests/unit/test_stream/test_stream.py
+++ b/tests/unit/test_stream/test_stream.py
@@ -2,6 +2,7 @@ import datetime
 from unittest.mock import MagicMock
 
 import pytest
+
 from bloop.models import BaseModel, Column
 from bloop.stream.coordinator import Coordinator
 from bloop.stream.stream import Stream

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1,9 +1,10 @@
+import datetime
 import decimal
 import uuid
 
-import datetime
 import declare
 import pytest
+
 from bloop.types import (
     UUID,
     Binary,

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -2,6 +2,7 @@ import collections
 import gc
 
 import pytest
+
 from bloop.util import (
     Sentinel,
     WeakDefaultDictionary,

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = unit, integ, docs
 
 [testenv]
-basepython = python3.5
+basepython = python3
 deps = -rrequirements.txt
 
 [testenv:unit]


### PR DESCRIPTION
* Adds `INFO` and `DEBUG` level logging to mutating operations
* Defaults `read_units` and `write_units` to `None`, only set to 1 when creating the table.  Otherwise the existing values from DynamoDB are loaded during `Engine.bind`.
* Drops python 3.4 support, uses 3.5+ syntax from [PEP 448 -- Additional Unpacking Generalizations](https://www.python.org/dev/peps/pep-0448/)
* Minor doc improvements:
  * New pattern: cross-region replication
  * New pattern: `Column` behavior extension
  * New pattern: minimal `Marshmallow` integration
  * User Guide: new section in Types clarifies that Bloop does no type validation