### PR TITLE
Added column metadata that just stores off extra data.

### DIFF
--- a/bloop/conditions.py
+++ b/bloop/conditions.py
@@ -803,7 +803,7 @@ class InCondition(BaseCondition):
 class ComparisonMixin:
     # noinspection PyArgumentList
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__()
 
     def __repr__(self):
         return "<ComparisonMixin>"

--- a/bloop/models.py
+++ b/bloop/models.py
@@ -390,8 +390,9 @@ class Column(ComparisonMixin):
         A model can have at most one Column with
         ``range_key=True``.  Default is False.
     :param str dynamo_name: *(Optional)* The index's name in in DynamoDB. Defaults to the index’s name in the model.
+    :param metadata: Extra arguments to be stored as metadata.
     """
-    def __init__(self, typedef, hash_key=False, range_key=False, dynamo_name=None, **kwargs):
+    def __init__(self, typedef, hash_key=False, range_key=False, dynamo_name=None, **metadata):
         self.hash_key: bool = hash_key
         self.range_key: bool = range_key
         self._name: str = None
@@ -402,7 +403,8 @@ class Column(ComparisonMixin):
             self.typedef = typedef
         else:
             raise TypeError(f"Expected {typedef} to be instance or subclass of Type")
-        super().__init__(**kwargs)
+        super().__init__(**metadata)
+        self.metadata = metadata
 
     def __copy__(self):
         cls = self.__class__

--- a/docs/api/public.rst
+++ b/docs/api/public.rst
@@ -81,6 +81,10 @@ See :ref:`defining models <define-models>` in the User Guide.
 
         True if this is the model's range key.
 
+    .. attribute:: metadata
+
+        All extra arguments are stored as metadata.
+
 ----------------------
  GlobalSecondaryIndex
 ----------------------

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -747,6 +747,15 @@ def test_column_dynamo_name():
     assert column.dynamo_name == "foo"
 
 
+def test_column_metadata():
+    """ Column metadata is available """
+    desc = "The id of the something or other"
+    column = Column(Integer, description=desc)
+
+    assert 'description' in column.metadata
+    assert column.metadata['description'] == desc
+
+
 def test_column_repr():
     column = Column(Integer, dynamo_name="f")
     column.model = User


### PR DESCRIPTION
For example, say that I want a `description` with each field that I use
to generate openapi/swagger docs with. You could do that like:

```
class MyModel(BaseModel):
    id = Column(Integer, hash_key=True, description="The model id")

description = MyModel.metadata['description']
```