### PR TITLE
Fix/111

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,21 @@ __ https://gist.github.com/numberoverzero/c5d0fc6dea624533d004239a27e545ad
 *(no unreleased changes)*
 
 --------------------
+ 2.0.1 - 2018-02-03
+--------------------
+
+Fix a bug where the last records in a closed shard in a Stream were dropped.  See `Issue #87`_ and
+`PR #112`_.
+
+.. _Issue #111: https://github.com/numberoverzero/bloop/issues/111
+.. _PR #112: https://github.com/numberoverzero/bloop/pull/112
+
+[Fixed]
+=======
+
+* ``Stream`` no longer drops the last records from a closed Shard when moving to the child shard.
+
+--------------------
  2.0.0 - 2017-11-27
 --------------------
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Joe Cross
+Copyright (c) 2018 Joe Cross
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,6 @@ docs:
 	firefox docs/_build/html/index.html
 
 publish:
+	- rm -fr build dist .egg bloop.egg-info
 	python setup.py sdist bdist_wheel
 	twine upload dist/*
-	rm -fr build dist .egg bloop.egg-info

--- a/bloop/__init__.py
+++ b/bloop/__init__.py
@@ -57,4 +57,4 @@ __all__ = [
     # Misc
     "Condition", "QueryIterator", "ScanIterator", "Stream", "missing"
 ]
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/bloop/stream/buffer.py
+++ b/bloop/stream/buffer.py
@@ -1,10 +1,4 @@
 import heapq
-import random
-
-
-def jitter():
-    """Used to advance a monotonic clock by a small amount"""
-    return random.randint(1, 5)
 
 
 def heap_item(clock, record, shard):
@@ -107,6 +101,6 @@ class RecordBuffer:
         # Try to prevent collisions from someone accessing the underlying int.
         # This offset ensures _RecordBuffer__monotonic_integer will never have
         # the same value as any call to clock().
-        value = self.__monotonic_integer + jitter()
-        self.__monotonic_integer = value + jitter()
+        value = self.__monotonic_integer + 1
+        self.__monotonic_integer += 2
         return value

--- a/bloop/stream/shard.py
+++ b/bloop/stream/shard.py
@@ -90,6 +90,9 @@ class Shard:
             details += ", "
         return "<{}[{}id={!r}]>".format(self.__class__.__name__, details, self.shard_id)
 
+    def __iter__(self):
+        return self
+
     def __next__(self):
         try:
             return self.get_records()
@@ -112,6 +115,8 @@ class Shard:
             )
         except (AttributeError, TypeError):
             return False
+
+    __hash__ = object.__hash__
 
     @property
     def exhausted(self):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ html_context = {
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.6', None),
     'arrow': ('https://arrow.readthedocs.io/en/latest/', None),
-    'PIL': ('https://pillow.readthedocs.io/en/3.4.x', None),
+    'PIL': ('https://pillow.readthedocs.io/en/latest', None),
     'blinker': ('https://pythonhosted.org/blinker/', None),
     'boto3': ('http://boto3.readthedocs.io/en/latest', None),
     'delorean': ('https://delorean.readthedocs.io/en/latest/', None)

--- a/tests/unit/test_stream/__init__.py
+++ b/tests/unit/test_stream/__init__.py
@@ -68,12 +68,15 @@ def dynamodb_record_with(key=False, new=False, old=False, sequence_number=None, 
         creation_time = 1.46480527E9
     else:
         creation_time = creation_time.timestamp()
+    if sequence_number is None:
+        sequence_number = "400000000000000499660"
+    sequence_number = str(sequence_number)
     creation_time = datetime.datetime.fromtimestamp(int(creation_time))
     template = {
         "awsRegion": "us-west-2",
         "dynamodb": {
             "ApproximateCreationDateTime": creation_time,
-            "SequenceNumber": str(sequence_number) if sequence_number is not None else "400000000000000499660",
+            "SequenceNumber": sequence_number,
             "SizeBytes": 41,
             "StreamViewType": "KEYS_ONLY",
 

--- a/tests/unit/test_stream/test_coordinator.py
+++ b/tests/unit/test_stream/test_coordinator.py
@@ -121,7 +121,6 @@ def test_advance_pulls_from_all_active_shards(coordinator, session):
     assert [has_records, no_records] == coordinator.active
 
 
-@pytest.mark.xfail(reason="expected failure, https://github.com/numberoverzero/bloop/issues/111")
 def test_buffer_closed_records(coordinator, session):
     """
     When a shard is closed, the last set of records is still buffered even though the shard is no longer tracked.
@@ -149,10 +148,21 @@ def test_buffer_closed_records(coordinator, session):
         "StreamArn": coordinator.stream_arn
     }
 
+    assert not coordinator.closed
+
     record = next(coordinator)
-    assert record["meta"]["sequence_number"] == "123"
-    assert len(coordinator.buffer) == 2
     assert not coordinator.active
+    assert record["meta"]["sequence_number"] == "123"
+    assert len(coordinator.buffer) == coordinator.closed[closed_shard] == 2
+
+    record = next(coordinator)
+    assert record["meta"]["sequence_number"] == "456"
+    assert len(coordinator.buffer) == coordinator.closed[closed_shard] == 1
+
+    record = next(coordinator)
+    assert record["meta"]["sequence_number"] == "789"
+    assert not coordinator.buffer
+    assert not coordinator.closed
 
 
 @pytest.mark.parametrize("has_children, loads_children", [(True, False), (False, False), (False, True)])
@@ -304,6 +314,60 @@ def test_token(coordinator):
     assert ordered(expected_token) == ordered(coordinator.token)
 
 
+def test_token_closed_records(coordinator, session):
+    """
+    When a shard is closed, the last set of records is still buffered even though the shard is no longer tracked.
+    The token must include the closed shard until its buffered records are consumed.
+
+    https://github.com/numberoverzero/bloop/issues/111
+    """
+    closed_shard = Shard(
+        stream_arn=coordinator.stream_arn,
+        shard_id="closed-shard-id",
+        iterator_id="closed-iter-id",
+        session=session)
+    coordinator.active = [closed_shard]
+
+    session.get_stream_records.return_value = {
+        "Records": [
+            dynamodb_record_with(sequence_number=123, key=True),
+            dynamodb_record_with(sequence_number=456, key=True),
+            dynamodb_record_with(sequence_number=789, key=True)
+        ]
+        # last records so no NextShardIterator
+    }
+
+    # called when the coordinator
+    session.describe_stream.return_value = {
+        "Shards": [],
+        "StreamArn": coordinator.stream_arn
+    }
+
+    initial_token = coordinator.token
+    assert initial_token == {
+        "stream_arn": "stream-arn",
+        "active": ["closed-shard-id"],
+        "shards": []
+    }
+
+    record = next(coordinator)
+    assert record["meta"]["sequence_number"] == "123"
+    assert coordinator.closed[closed_shard] == len(coordinator.buffer) == 2
+
+    # the token should still include the shard in "active", and the "shards"
+    # list should contain a pointer to the sequence number 123
+    token = coordinator.token
+    assert token == {
+        "stream_arn": "stream-arn",
+        "active": ["closed-shard-id"],
+        "shards": [{
+            "iterator_type": "after_sequence",
+            "sequence_number": "123",
+            "shard_id": "closed-shard-id",
+        }]
+    }
+
+
 @pytest.mark.parametrize("is_active", [True, False])
 @pytest.mark.parametrize("is_root", [True, False])
 @pytest.mark.parametrize("has_buffered", [True, False])
@@ -325,7 +389,7 @@ def test_remove_shard(is_active, is_root, has_buffered, coordinator):
         coordinator.buffer.push_all((r, shard) for r in records)
     coordinator.buffer.push(local_record(sequence_number="200"), other)
 
-    coordinator.remove_shard(shard)
+    coordinator.remove_shard(shard, drop_buffered_records=True)
 
     if is_active:
         assert all(child in coordinator.active for child in children)

--- a/tests/unit/test_stream/test_shard.py
+++ b/tests/unit/test_stream/test_shard.py
@@ -168,6 +168,10 @@ def test_eq_not_set_or_different(attr):
     assert not other == shard
 
 
+def test_iter(shard):
+    assert iter(shard) is shard
+
+
 def test_exhausted(shard):
     assert shard.iterator_id is None
     assert not shard.exhausted


### PR DESCRIPTION
This fixes a bug where the records of the last GetRecords call in a closed Shard are dropped from the Coordinator's buffer immediately.  See #111 for investigation details.

Now, the Coordinator keeps a count of buffered records for each closed shard that it previously tracked; as each record is popped off the buffer, the count is decremented until it's dropped.  The Shards can't be tracked in the same place as active shards (`Coordinator.active`) because those are periodically polled for more records.  However, we can't stop tracking them because then the rendered `Shard.token` would skip ahead while the records are still buffered.


In addition to unit tests, I ran some hacked together tests for a few hours; records were inserted every 30mins/1min/10sec in 3 different streams and then counted on the way out of the `Stream` processor.