### PR TITLE
Support Point-in-time-recovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
+dist: trusty
+sudo: required
 language: python
 python: 3.6
 cache: pip
+services:
+  - docker
 env:
   matrix:
   - TOXENV=unit
@@ -18,8 +22,3 @@ notifications:
     on_success: change
     on_failure: always
     on_start: never
-
-# container-based for faster builds
-sudo: false
-# tls 1.2
-dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 dist: trusty
 sudo: required
 language: python
+dist: trusty
 python: 3.6
 cache: pip
 services:
@@ -11,7 +12,7 @@ env:
   - TOXENV=integ
   - TOXENV=docs
 install: pip install tox codecov
-script: tox -e $TOXENV
+script: tox -e $TOXENV -- -s
 
 notifications:
   slack:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,20 @@ __ https://gist.github.com/numberoverzero/c5d0fc6dea624533d004239a27e545ad
  Unreleased
 ------------
 
-*(no unreleased changes)*
+For release plans, see the `2.2 milestone`_
+
+[Added]
+=======
+
+* Meta supports `Continuous Backups`_ for Point-In-Time Recovery::
+
+    class MyModel(BaseModel):
+        id = Column(String, hash_key=True)
+        class Meta:
+            backups = {"enabled": True}
+
+.. _Continuous Backups: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/BackupRestore.html
+.. _2.2 milestone: https://github.com/numberoverzero/bloop/milestone/5
 
 --------------------
  2.1.0 - 2018-04-07

--- a/bloop/__init__.py
+++ b/bloop/__init__.py
@@ -34,7 +34,6 @@ from .types import (
     String,
     Timestamp,
 )
-
 from .util import missing
 
 

--- a/bloop/engine.py
+++ b/bloop/engine.py
@@ -182,7 +182,7 @@ class Engine:
             if not skip_table_setup:
                 table_name = self._compute_table_name(model)
                 if is_creating[model]:
-                    # poll until table is active
+                    # polls until table is active
                     self.session.describe_table(table_name)
                     if model.Meta.ttl:
                         self.session.enable_ttl(table_name, model)

--- a/bloop/engine.py
+++ b/bloop/engine.py
@@ -181,9 +181,13 @@ class Engine:
         for model in concrete:
             if not skip_table_setup:
                 table_name = self._compute_table_name(model)
-                if is_creating[model] and model.Meta.ttl:
+                if is_creating[model]:
+                    # poll until table is active
                     self.session.describe_table(table_name)
-                    self.session.enable_ttl(table_name, model)
+                    if model.Meta.ttl:
+                        self.session.enable_ttl(table_name, model)
+                    if model.Meta.backups and model.Meta.backups["enabled"]:
+                        self.session.enable_backups(table_name, model)
                 self.session.validate_table(table_name, model)
 
             model_validated.send(self, engine=self, model=model)

--- a/bloop/models.py
+++ b/bloop/models.py
@@ -51,6 +51,7 @@ class IMeta:
     stream: Optional[Dict]
     ttl: Optional[Dict]
     encryption: Optional[Dict]
+    backups: Optional[Dict]
 
     model: "BaseModel"
 
@@ -191,6 +192,7 @@ class BaseModel:
         validate_stream(meta)
         validate_ttl(meta)
         validate_encryption(meta)
+        validate_backups(meta)
 
         # 3.0 Fire model_created for customizing the class after creation
         model_created.send(None, model=cls)
@@ -671,6 +673,17 @@ def validate_encryption(meta):
         raise InvalidModel("Encryption must specify whether it is enabled with the 'enabled' key.")
 
 
+def validate_backups(meta):
+    backups = meta.backups
+    if backups is None:
+        return
+
+    if not isinstance(backups, collections.abc.MutableMapping):
+        raise InvalidModel("Backups must be None or a dict.")
+    if "enabled" not in backups:
+        raise InvalidModel("Backups must specify whether it is enabled with the 'enabled' key.")
+
+
 def validate_ttl(meta):
     ttl = meta.ttl
     if ttl is None:
@@ -759,6 +772,7 @@ def initialize_meta(cls: type):
     setdefault(meta, "stream", None)
     setdefault(meta, "ttl", None)
     setdefault(meta, "encryption", None)
+    setdefault(meta, "backups", None)
 
     setdefault(meta, "hash_key", None)
     setdefault(meta, "range_key", None)

--- a/bloop/session.py
+++ b/bloop/session.py
@@ -427,6 +427,16 @@ def compare_tables(model, actual):
             logger.debug(f"Model expects SSE to be '{expected_sse}' but was '{actual_sse}'")
             matches = False
 
+    if model.Meta.backups:
+        actual_backups = actual["ContinuousBackupsDescription"]["ContinuousBackupsStatus"]
+        expected_backups = {
+            True: "ENABLED",
+            False: "DISABLED"
+        }[model.Meta.backups["enabled"]]
+        if actual_backups != expected_backups:
+            logger.debug(f"Model expects backups to be '{expected_backups}' but was '{actual_backups}'")
+            matches = False
+
     if model.Meta.stream:
         if not actual["StreamSpecification"]["StreamEnabled"]:
             logger.debug("Model expects streaming but streaming is not enabled")

--- a/bloop/session.py
+++ b/bloop/session.py
@@ -262,7 +262,7 @@ class SessionWrapper:
         """
         request = {
             "TableName": table_name,
-            " PointInTimeRecoverySpecification ": {"PointInTimeRecoveryEnabled": True}
+            "PointInTimeRecoverySpecification": {"PointInTimeRecoveryEnabled": True}
         }
         try:
             self.dynamodb_client.update_continuous_backups(**request)

--- a/bloop/session.py
+++ b/bloop/session.py
@@ -244,6 +244,22 @@ class SessionWrapper:
         except botocore.exceptions.ClientError as error:
             raise BloopException("Unexpected error while setting TTL.") from error
 
+    def enable_backups(self, table_name, model):
+        """Calls UpdateContinuousBackups on the table according to model.Meta["continuous_backups"]
+
+        :param table_name: The name of the table to enable Continuous Backups on
+        :param model: The model to get Continuous Backups settings from
+        """
+        assert model.Meta.backups["enabled"]
+        request = {
+            "TableName": table_name,
+            " PointInTimeRecoverySpecification ": {"PointInTimeRecoveryEnabled": True}
+        }
+        try:
+            self.dynamodb_client.update_continuous_backups(**request)
+        except botocore.exceptions.ClientError as error:
+            raise BloopException("Unexpected error while setting Continuous Backups.") from error
+
     def describe_stream(self, stream_arn, first_shard=None):
         """Wraps :func:`boto3.DynamoDBStreams.Client.describe_stream`, handling continuation tokens.
 

--- a/bloop/stream/coordinator.py
+++ b/bloop/stream/coordinator.py
@@ -2,7 +2,6 @@ import collections
 import collections.abc
 import datetime
 import logging
-
 from typing import Dict, List
 
 from ..exceptions import InvalidPosition, InvalidStream, RecordsExpired

--- a/bloop/util.py
+++ b/bloop/util.py
@@ -4,7 +4,7 @@ import weakref
 import blinker
 
 
-__all__ = ["Sentinel", "ordered", "signal"]
+__all__ = ["Sentinel", "ordered", "signal", "walk_subclasses"]
 
 # De-dupe dict for Sentinel
 _symbols = {}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,8 +20,9 @@ Features
 * Expressive conditions
 * Model composition
 * Diff-based saves
-* Server side encryption
-* Time to live
+* Server-Side-Encryption
+* Time-To-Live
+* Continuous Backups
 
 ==========
 Ergonomics

--- a/docs/meta/about.rst
+++ b/docs/meta/about.rst
@@ -18,12 +18,12 @@ To start developing Bloop first `create a fork`_, then clone and run the tests::
 
 .. note::
 
-    The integration tests use `DynamoDBLocal`_ which requires JRE >= 6.x.  The tests automatically download and unpack
-    the software into ``.dynamodb_local`` and start the process as follows, where the port is selected at runtime::
+    The integration tests use `docker`_ to run a `local instance of DynamoDB`_.  The tests automatically
+    start and tear down an image named ``"ddb-local"`` that uses port ``8000``.  You can use ``--skip-cleanup``
+    to leave the container running after tests finish.
 
-        java -Djava.library.path=./DynamoDBLocal_lib -jar DynamoDBLocal.jar -inMemory -port {PORT}
-
-.. _DynamoDBLocal: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html
+.. _docker: https://www.docker.com/get-started
+.. _local instance of DynamoDB: https://hub.docker.com/r/amazon/dynamodb-local/
 
 .. _meta-versioning:
 

--- a/docs/user/models.rst
+++ b/docs/user/models.rst
@@ -127,6 +127,7 @@ Table configuration defaults are:
             stream = None
             ttl = None
             encryption = None
+            backups = None
 
 
 ----------
@@ -223,7 +224,7 @@ popular python datetime libraries: arrow, delorean, and pendulum.
  encryption
 ------------
 
-Finally, you can use ``encryption`` to enable `Server-Side Encryption`__.  By default encryption is not enabled, and
+You can use ``encryption`` to enable `Server-Side Encryption`_.  By default encryption is not enabled, and
 this is ``None``.  To enable server-side encryption, use:
 
 .. code-block:: python
@@ -233,7 +234,23 @@ this is ``None``.  To enable server-side encryption, use:
             "enabled": True
         }
 
-__ https://aws.amazon.com/blogs/aws/new-encryption-at-rest-for-dynamodb/
+.. _Server-Side Encryption: https://aws.amazon.com/blogs/aws/new-encryption-at-rest-for-dynamodb/
+
+---------
+ backups
+---------
+
+You can use ``backups`` to enable `Continuous Backups`_ and Point-in-Time Recovery.  By default continuous backups
+are not enabled, and this is ``None``.  To enable continuous backups, use:
+
+.. code-block:: python
+
+    class Meta:
+        backups = {
+            "enabled": True
+        }
+
+.. _Continuous Backups: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/BackupRestore.html
 
 ===============================
  Metadata: Model Introspection

--- a/docs/user/models.rst
+++ b/docs/user/models.rst
@@ -264,6 +264,7 @@ These top-level properties can be used to describe the model in broad terms:
 
 * ``model`` -- The model this Meta is attached to
 * ``columns`` -- The set of all columns in the model
+* ``columns_by_name`` -- Dictionary of model Column objects by their ``name`` attribute.
 * ``keys`` -- The set of all table keys in the model (hash key, or hash and range keys)
 * ``indexes`` -- The set of all indexes (gsis, lsis) in the model
 

--- a/docs/user/models.rst
+++ b/docs/user/models.rst
@@ -174,6 +174,38 @@ the table or GSI does not exist, they fall back to 1.
     is controlled by an external script, and totally broken with the new auto-scaling features.
 
 ---------
+ backups
+---------
+
+You can use ``backups`` to enable `Continuous Backups`_ and Point-in-Time Recovery.  By default continuous backups
+are not enabled, and this is ``None``.  To enable continuous backups, use:
+
+.. code-block:: python
+
+    class Meta:
+        backups = {
+            "enabled": True
+        }
+
+.. _Continuous Backups: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/BackupRestore.html
+
+------------
+ encryption
+------------
+
+You can use ``encryption`` to enable `Server-Side Encryption`_.  By default encryption is not enabled, and
+this is ``None``.  To enable server-side encryption, use:
+
+.. code-block:: python
+
+    class Meta:
+        encryption = {
+            "enabled": True
+        }
+
+.. _Server-Side Encryption: https://aws.amazon.com/blogs/aws/new-encryption-at-rest-for-dynamodb/
+
+---------
  stream
 ---------
 
@@ -220,37 +252,6 @@ for your convenience, and is used as a class:`datetime.datetime`:
 Like :class:`~bloop.types.DateTime`, ``bloop.ext`` exposes drop-in replacements for ``Timestamp`` for each of three
 popular python datetime libraries: arrow, delorean, and pendulum.
 
-------------
- encryption
-------------
-
-You can use ``encryption`` to enable `Server-Side Encryption`_.  By default encryption is not enabled, and
-this is ``None``.  To enable server-side encryption, use:
-
-.. code-block:: python
-
-    class Meta:
-        encryption = {
-            "enabled": True
-        }
-
-.. _Server-Side Encryption: https://aws.amazon.com/blogs/aws/new-encryption-at-rest-for-dynamodb/
-
----------
- backups
----------
-
-You can use ``backups`` to enable `Continuous Backups`_ and Point-in-Time Recovery.  By default continuous backups
-are not enabled, and this is ``None``.  To enable continuous backups, use:
-
-.. code-block:: python
-
-    class Meta:
-        backups = {
-            "enabled": True
-        }
-
-.. _Continuous Backups: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/BackupRestore.html
 
 ===============================
  Metadata: Model Introspection

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 arrow==0.10.0
 blinker==1.4
-boto3>=1.7.1,<=1.8.0
+boto3>=1.7.1,<1.8.0
 botocore>=1.10.1
 coverage==4.5.1
 delorean==0.6.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ for line in (HERE / "bloop" / "__init__.py").read_text().split("\n"):
 
 REQUIREMENTS = [
     "blinker==1.4",
-    "boto3>=1.7.1,<=1.8.0",
+    "boto3>=1.7.1,<1.8.0",
     "botocore>=1.10.1"  # no upper bound because we'll take what boto3 uses
 ]
 

--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -1,25 +1,18 @@
-import contextlib
-import hashlib
-import os
 import random
-import shutil
-import socket
 import string
 import subprocess
-import zipfile
 
 import boto3
 import pytest
-import requests
 from tests.helpers.utils import get_tables
 
 from bloop import BaseModel, BloopException, Engine
 from bloop.session import SessionWrapper
 from bloop.util import walk_subclasses
 
-
-LATEST_DYNAMODB_LOCAL_SHA = "70d9a92529782ac93713258fe69feb4ff6e007ae2c3319c7ffae7da38b698a61"
-DYNAMODB_LOCAL_SINGLETON = None
+DOCKER_START_COMMAND = ["docker", "run", "-d", "-p", "8000:8000", "--name", "ddb-local", "amazon/dynamodb-local"]
+DOCKER_STOP_COMMAND = ["docker", "stop", "ddb-local"]
+DOCKER_RM_COMMAND = ["docker", "rm", "ddb-local"]
 
 
 class PatchedDynamoDBClient:
@@ -37,14 +30,8 @@ class PatchedDynamoDBClient:
 
 
 class DynamoDBLocal:
-    def __init__(self, localdir: str) -> None:
-        self.localdir = localdir
-        self.process = None  # type: subprocess.Popen
-        self.port = None
-
-    @property
-    def running(self) -> bool:
-        return self.process is not None
+    def __init__(self) -> None:
+        self.running = False
 
     @property
     def session(self) -> boto3.Session:
@@ -58,7 +45,7 @@ class DynamoDBLocal:
     @property
     def endpoint(self) -> str:
         assert self.running
-        return "http://localhost:" + str(self.port)
+        return "http://localhost:8000"
 
     @property
     def clients(self) -> tuple:
@@ -74,73 +61,14 @@ class DynamoDBLocal:
 
     def start(self) -> None:
         assert not self.running
-        self._download()
-        self._reserve_port()
-        self.process = self._run()
+        self.running = True
+        subprocess.run(DOCKER_START_COMMAND, stdout=subprocess.PIPE, check=True)
 
     def stop(self) -> None:
         assert self.running
-        self.process.terminate()
-
-    def _download(self) -> None:
-        if os.path.exists(self.localdir):
-            return
-        print("\n".join((
-            "*" * 79,
-            "DynamoDBLocal doesn't exist, installing at {}".format(self.localdir),
-            "*" * 79
-        )))
-
-        # need a temp directory to download it in...
-        tempdir = self.localdir + ".tmp"
-        if os.path.exists(tempdir):
-            shutil.rmtree(tempdir)
-        os.mkdir(tempdir)
-
-        r = requests.get("https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.zip",
-                         stream=True)
-        dist = os.path.join(tempdir, "dynamodb_local_latest.zip")
-
-        # download in chucks, checking its sha256 hash along the way
-        sha = hashlib.sha256()
-        with open(dist, "wb") as f:
-            for chunk in r.iter_content(chunk_size=1024):
-                if chunk:
-                    f.write(chunk)
-                    sha.update(chunk)
-
-        # Is this the file we're looking for?
-        if sha.hexdigest() != LATEST_DYNAMODB_LOCAL_SHA:
-            msg = "Invalid hash of {}/dynamodb_local_latest.zip -- expected {} but was {}"
-            raise RuntimeError(msg.format(tempdir, LATEST_DYNAMODB_LOCAL_SHA, sha.hexdigest()))
-
-        zip_ref = zipfile.ZipFile(dist, "r")
-        zip_ref.extractall(tempdir)
-        zip_ref.close()
-
-        # clean up
-        os.rename(tempdir, self.localdir)
-
-    def _reserve_port(self) -> None:
-        """
-        By using a socket and binding to "" (localhost), with a port of 0 (socket picks first non-privileged port
-        that is not in use, we can ensure that the port is available.
-        See:  https://stackoverflow.com/questions/2838244/get-open-tcp-port-in-python/2838309#2838309
-        and   https://stackoverflow.com/a/45690594
-        :return: The port to use
-        """
-        with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-            s.bind(("", 0))
-            s.listen(1)
-            self.port = s.getsockname()[1]
-
-    def _run(self) -> subprocess.Popen:
-        return subprocess.Popen([
-            "java", "-Djava.library.path=./DynamoDBLocal_lib",
-            "-jar", "DynamoDBLocal.jar", "-inMemory",
-            "-port", str(self.port)],
-            cwd=self.localdir
-        )
+        subprocess.run(DOCKER_STOP_COMMAND, stdout=subprocess.PIPE, check=True)
+        subprocess.run(DOCKER_RM_COMMAND, stdout=subprocess.PIPE, check=True)
+        self.running = False
 
 
 def pytest_addoption(parser):
@@ -150,7 +78,7 @@ def pytest_addoption(parser):
         help="make table names unique for parallel runs")
     parser.addoption(
         "--skip-cleanup", action="store_true", default=False,
-        help="don't clean up tables after tests run")
+        help="don't clean up the docker instance after tests run")
 
     default_localdir = ".dynamodb-local"
     parser.addoption(
@@ -162,31 +90,31 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="session")
 def dynamodb_local(request):
     nonce = request.config.getoption("--nonce")
-    localdir = request.config.getoption("--dynamodb-local-dir")
     skip_cleanup = request.config.getoption("--skip-cleanup")
 
-    dynamodb_local = DynamoDBLocal(localdir)
+    dynamodb_local = DynamoDBLocal()
     dynamodb_local.start()
 
     yield dynamodb_local
 
+    if skip_cleanup:
+        print("Skipping cleanup, leaving docker image intact")
+        return
     try:
-        if skip_cleanup:
-            print("Skipping cleanup")
-        else:
-            print("Cleaning up tables with nonce '{}'".format(nonce))
-            dynamodb, _ = dynamodb_local.clients
-            tables = get_tables(dynamodb)
-            for table in tables:
-                if nonce not in table:
-                    continue
-                # noinspection PyBroadException
-                try:
-                    print("Removing table: {}".format(table))
-                    dynamodb.delete_table(TableName=table)
-                except Exception:
-                    print("Failed to clean up table '{}'".format(table))
+        print("Cleaning up tables with nonce '{}'".format(nonce))
+        dynamodb, _ = dynamodb_local.clients
+        tables = get_tables(dynamodb)
+        for table in tables:
+            if nonce not in table:
+                continue
+            # noinspection PyBroadException
+            try:
+                print("Removing table: {}".format(table))
+                dynamodb.delete_table(TableName=table)
+            except Exception:
+                print("Failed to clean up table '{}'".format(table))
     finally:
+        print("Shutting down ddb-local")
         dynamodb_local.stop()
 
 

--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -29,6 +29,9 @@ class PatchedDynamoDBClient:
     def describe_time_to_live(self, **_):
         return {"TimeToLiveDescription": {"TimeToLiveStatus": "DISABLED"}}
 
+    def describe_continuous_backups(self, **_):
+        return {"ContinuousBackupsDescription": {"ContinuousBackupsStatus": "DISABLED"}}
+
     def __getattr__(self, name):
         return getattr(self.__client, name)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 import logging
 import pytest
 
-from bloop import BaseModel, Engine
+from bloop import Engine
 from bloop.session import SessionWrapper
 from bloop.signals import (
     object_deleted,
@@ -39,7 +39,6 @@ def engine(session, dynamodb, dynamodbstreams):
     engine = Engine(dynamodb=dynamodb, dynamodbstreams=dynamodbstreams)
     # Toss the clients above and hook up the mock session
     engine.session = session
-    engine.bind(BaseModel)
     return engine
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,6 @@
-from unittest.mock import Mock
 import logging
+from unittest.mock import Mock
+
 import pytest
 
 from bloop import Engine

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -4,6 +4,7 @@ import uuid
 from unittest.mock import Mock
 
 import pytest
+from tests.helpers.models import ComplexModel, User, VectorModel
 
 from bloop.engine import Engine, dump_key
 from bloop.exceptions import (
@@ -19,8 +20,6 @@ from bloop.session import SessionWrapper
 from bloop.signals import object_saved
 from bloop.types import DateTime, Integer, String, Timestamp
 from bloop.util import ordered
-
-from tests.helpers.models import ComplexModel, User, VectorModel
 
 
 def test_default_table_name_template(dynamodb, dynamodbstreams, session):
@@ -740,11 +739,12 @@ def test_bind_configures_backups(engine, session):
 def test_bind_existing_table(engine, session):
     """Even though backups/ttl are specified, no UpdateTTL/etc calls made because the table exists"""
     class MyUser(BaseModel):
-        id = Column(Integer, hash_key=True)
-        expiry = Column(Timestamp)
         class Meta:
             backups = {"enabled": True}
             ttl = {"column": "expiry"}
+
+        id = Column(Integer, hash_key=True)
+        expiry = Column(Timestamp)
 
     session.create_table.return_value = False
     engine.bind(MyUser)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -485,6 +485,15 @@ def test_invalid_encryption(invalid_encryption):
             id = Column(Integer, hash_key=True)
 
 
+@pytest.mark.parametrize("invalid_backups", [False, True, {}, User.age])
+def test_invalid_backups(invalid_backups):
+    with pytest.raises(InvalidModel):
+        class Model(BaseModel):
+            class Meta:
+                backups = invalid_backups
+            id = Column(Integer, hash_key=True)
+
+
 @pytest.mark.parametrize("valid_stream", [
     {"include": ["new"]},
     {"include": ["old"]},
@@ -512,6 +521,20 @@ def test_valid_encryption(valid_encryption):
 
         id = Column(Integer, hash_key=True)
     assert Model.Meta.encryption is valid_encryption
+
+
+@pytest.mark.parametrize("valid_backups", [
+    {"enabled": True},
+    {"enabled": False},
+    {"enabled": True, "unused": object()}
+])
+def test_valid_backups(valid_backups):
+    class Model(BaseModel):
+        class Meta:
+            backups = valid_backups
+
+        id = Column(Integer, hash_key=True)
+    assert Model.Meta.backups is valid_backups
 
 
 def test_require_hash():

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -624,6 +624,30 @@ def test_enable_ttl_wraps_exception(session, dynamodb):
         session.enable_ttl("LocalTableName", Model)
     assert excinfo.value.__cause__ is expected
 
+
+def test_enable_backups(session, dynamodb):
+    class Model(BaseModel):
+        class Meta:
+            backups = {"enabled": True}
+        id = Column(String, hash_key=True)
+    session.enable_backups("LocalTableName", Model)
+    expected = {
+        "TableName": "LocalTableName",
+        "PointInTimeRecoverySpecification": {"PointInTimeRecoveryEnabled": True}
+    }
+    dynamodb.update_continuous_backups.assert_called_once_with(**expected)
+
+
+def test_enable_backups_wraps_exception(session, dynamodb):
+    class Model(BaseModel):
+        class Meta:
+            backups = {"enabled": True}
+        id = Column(String, hash_key=True)
+    dynamodb.update_continuous_backups.side_effect = expected = client_error("FooError")
+    with pytest.raises(BloopException) as excinfo:
+        session.enable_backups("LocalTableName", Model)
+    assert excinfo.value.__cause__ is expected
+
 # VALIDATE TABLE ====================================================================================== VALIDATE TABLE
 
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -14,7 +14,12 @@ from bloop.exceptions import (
     ShardIteratorExpired,
     TableMismatch,
 )
-from bloop.models import BaseModel, Column, GlobalSecondaryIndex, LocalSecondaryIndex
+from bloop.models import (
+    BaseModel,
+    Column,
+    GlobalSecondaryIndex,
+    LocalSecondaryIndex,
+)
 from bloop.session import (
     BATCH_GET_ITEM_CHUNK_SIZE,
     SessionWrapper,


### PR DESCRIPTION
This adds a `backups` key to `model.Meta` to enable Continuous Backups:

```
class MyModel(BaseModel):
    id = Column(String, hash_key=True)
    class Meta:
        backups = {"enabled": True}
```

see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/BackupRestore.html