### PR TITLE
docs: fix `dynamo_name` examples in models.rst

### DIFF
--- a/docs/api/public.rst
+++ b/docs/api/public.rst
@@ -78,7 +78,7 @@ See :ref:`defining models <define-models>` in the User Guide.
 
             >>> class Document(BaseModel):
             ...     ...
-            ...     cheat_codes = Column(Set(String), name="cc")
+            ...     cheat_codes = Column(Set(String), dynamo_name="cc")
             ...
             >>> Document.cheat_codes.name
             cheat_codes
@@ -121,7 +121,7 @@ See :ref:`defining models <define-models>` in the User Guide.
             >>> class Document(BaseModel):
             ...     ...
             ...     by_email = GlobalSecondaryIndex(
-            ...         projection="keys", name="ind_e", hash_key="email")
+            ...         projection="keys", dynamo_name="ind_e", hash_key="email")
             ...
             >>> Document.by_email.name
             by_email
@@ -184,7 +184,7 @@ See :ref:`defining models <define-models>` in the User Guide.
             >>> class Document(BaseModel):
             ...     ...
             ...     by_date = LocalSecondaryIndex(
-            ...         projection="keys", name="ind_co", range_key="created_on")
+            ...         projection="keys", dynamo_name="ind_co", range_key="created_on")
             ...
             >>> Document.by_date.name
             by_date

--- a/docs/user/models.rst
+++ b/docs/user/models.rst
@@ -359,7 +359,7 @@ a column can't be both, there can't be more than one of each, and there must be 
 
 By default values will be stored in DynamoDB under the name of the column in the model definition (its ``name``).
 If you want to conserve read and write units, you can use shorter names for attributes in DynamoDB (attribute names
-are counted against your provisioned throughput).  Like the ``table_name`` in Meta, the optional ``name`` parameter
+are counted against your provisioned throughput).  Like the ``table_name`` in Meta, the optional ``dynamo_name`` parameter
 lets you use descriptive model names without binding you to those names in DynamoDB.  This is also convenient when
 mapping an existing table, or multi-model tables where an attribute can be interpreted multiple ways.
 
@@ -368,8 +368,8 @@ The following model is identical to the one just defined, except that each attri
 .. code-block:: python
 
     class Impression(BaseModel):
-        referrer = Column(String, hash_key=True, name="ref")
-        version = Column(Integer, range_key=True, name="v")
+        referrer = Column(String, hash_key=True, dynamo_name="ref")
+        version = Column(Integer, range_key=True, dynamo_name="v")
 
 Locally, the model names "referrer" and "version" are still used.  An instance would be constructed as usual:
 
@@ -515,14 +515,14 @@ instead default to 1.
 
     GlobalSecondaryIndex("all", hash_key=version, read_units=500, write_units=20)
 
-As with :class:`~bloop.models.Column` you can provide a ``name`` for the GSI in DynamoDB.  This can be used to map
+As with :class:`~bloop.models.Column` you can provide a ``dynamo_name`` for the GSI in DynamoDB.  This can be used to map
 to an existing index while still using a pythonic model name locally:
 
 .. code-block:: python
 
     class Impression(BaseModel):
         ...
-        by_email = GlobalSecondaryIndex("keys", hash_key=email, name="index_email")
+        by_email = GlobalSecondaryIndex("keys", hash_key=email, dynamo_name="index_email")
 
 .. seealso::
 
@@ -549,11 +549,11 @@ You can specify a name to use in DynamoDB, just like :class:`~bloop.models.Colum
 
     class Impression(BaseModel):
         url = Column(String, hash_key=True)
-        user_agent = Column(String, range_key=True, name="ua")
-        visited_at = Column(DateTime, name="at")
+        user_agent = Column(String, range_key=True, dynamo_name="ua")
+        visited_at = Column(DateTime, dynamo_name="at")
 
         by_date = LocalSecondaryIndex(
-        "keys", range_key=visited_at, name="index_date")
+        "keys", range_key=visited_at, dynamo_name="index_date")
 
 The final optional parameter is ``strict``, which defaults to True.  This controls whether DynamoDB may incur
 additional reads on the table when querying the LSI for columns outside the projection.  Bloop enforces this by

--- a/docs/user/patterns.rst
+++ b/docs/user/patterns.rst
@@ -130,7 +130,7 @@ as it will cause issues comparing values.
 ============================
 
 Bloop allows you to map multiple models to the same table.  You can rename columns during
-init with the ``name=`` param, change column types across models, and still use conditional
+init with the ``dynamo_name=`` param, change column types across models, and still use conditional
 operations and Bloop's atomic builder.  This flexibility extends to GSIs and LSIs as long
 as a Model's Index projects a subset of the actual Index.  On shared tables, a shared index
 provides tighter query validation and reduces consumed throughput.


### PR DESCRIPTION
Fixes misleading examples in documentation regarding `name` and `dynamo_name`