### PR TITLE
Transactions and On-Demand Billing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,16 @@ Let's make a few users and persist them:
     >>> support.id = uuid.uuid4()
     >>> engine.save(admin, support)
 
+Or do the same in a transaction:
+
+.. code-block:: python
+
+    >>> with engine.transaction() as tx:
+    ...     tx.save(admin)
+    ...     tx.save(support)
+    ...
+    >>>
+
 And find them again:
 
 .. code-block:: python

--- a/bloop/__init__.py
+++ b/bloop/__init__.py
@@ -21,6 +21,7 @@ from .signals import (
     object_saved,
 )
 from .stream import Stream
+from .transactions import Transaction
 from .types import (
     UUID,
     Binary,
@@ -57,6 +58,6 @@ __all__ = [
     "DynamicList", "DynamicMap",
 
     # Misc
-    "Condition", "QueryIterator", "ScanIterator", "Stream", "missing"
+    "Condition", "QueryIterator", "ScanIterator", "Stream", "Transaction", "missing"
 ]
-__version__ = "2.2.0"
+__version__ = "2.3.0"

--- a/bloop/__init__.py
+++ b/bloop/__init__.py
@@ -7,6 +7,7 @@ from .exceptions import (
     RecordsExpired,
     ShardIteratorExpired,
     TableMismatch,
+    TransactionCanceled
 )
 from .models import BaseModel, Column, GlobalSecondaryIndex, LocalSecondaryIndex
 from .search import QueryIterator, ScanIterator
@@ -47,7 +48,7 @@ __all__ = [
 
     # Exceptions
     "BloopException", "ConstraintViolation", "MissingObjects",
-    "RecordsExpired", "ShardIteratorExpired", "TableMismatch",
+    "RecordsExpired", "ShardIteratorExpired", "TableMismatch", "TransactionCanceled",
 
     # Signals
     "before_create_table", "model_bound", "model_created", "model_validated",

--- a/bloop/__init__.py
+++ b/bloop/__init__.py
@@ -21,7 +21,7 @@ from .signals import (
     object_saved,
 )
 from .stream import Stream
-from .transactions import Transaction
+from .transactions import ReadTransaction, WriteTransaction
 from .types import (
     UUID,
     Binary,
@@ -58,6 +58,6 @@ __all__ = [
     "DynamicList", "DynamicMap",
 
     # Misc
-    "Condition", "QueryIterator", "ScanIterator", "Stream", "Transaction", "missing"
+    "Condition", "QueryIterator", "ReadTransaction", "ScanIterator", "Stream", "WriteTransaction", "missing"
 ]
 __version__ = "2.3.0"

--- a/bloop/conditions.py
+++ b/bloop/conditions.py
@@ -13,7 +13,7 @@ from .signals import (
 from .util import WeakDefaultDictionary, missing
 
 
-__all__ = ["Condition", "render"]
+__all__ = ["BaseCondition", "ComparisonMixin", "Condition", "iter_columns", "render"]
 
 
 comparison_aliases = {

--- a/bloop/engine.py
+++ b/bloop/engine.py
@@ -387,7 +387,7 @@ class Engine:
         stream.move_to(position=position)
         return stream
 
-    def tx(self, mode="w"):
+    def transaction(self, mode="w"):
         """
         Create a new :class:`~bloop.transactions.ReadTransaction` or :class:`~bloop.transactions.WriteTransaction`.
 
@@ -398,7 +398,7 @@ class Engine:
             >>> engine = Engine()
             >>> user = User(id=3, email="user@domain.com")
             >>> tweet = Tweet(id=42, data="hello, world")
-            >>> with engine.tx("w") as tx:
+            >>> with engine.transaction("w") as tx:
             ...     tx.delete(user)
             ...     tx.save(tweet, condition=Tweet.id.is_(None))
 
@@ -409,7 +409,7 @@ class Engine:
             >>> engine = Engine()
             >>> user = User(id=3, email="user@domain.com")
             >>> tweet = Tweet(id=42, data="hello, world")
-            >>> tx = engine.tx("w")
+            >>> tx = engine.transaction("w")
             >>> tx.delete(user)
             >>> tx.save(tweet, condition=Tweet.id.is_(None))
             >>> tx.commit()

--- a/bloop/engine.py
+++ b/bloop/engine.py
@@ -23,45 +23,11 @@ from .signals import (
 )
 from .stream import Stream
 from .transactions import new_tx
-from .util import missing, walk_subclasses
+from .util import dump_key, extract_key, index_for, walk_subclasses
 
 
 __all__ = ["Engine"]
 logger = logging.getLogger("bloop.engine")
-
-
-def value_of(column):
-    """value_of({'S': 'Space Invaders'}) -> 'Space Invaders'"""
-    return next(iter(column.values()))
-
-
-def index_for(key):
-    """index_for({'id': {'S': 'foo'}, 'range': {'S': 'bar'}}) -> ('bar', 'foo')"""
-    return tuple(sorted(value_of(k) for k in key.values()))
-
-
-def extract_key(key_shape, item):
-    """construct a key according to key_shape for building an index"""
-    return {field: item[field] for field in key_shape}
-
-
-def dump_key(engine, obj):
-    """dump the hash (and range, if there is one) key(s) of an object into
-    a dynamo-friendly format.
-
-    returns {dynamo_name: {type: value} for dynamo_name in hash/range keys}
-    """
-    key = {}
-    for key_column in obj.Meta.keys:
-        key_value = getattr(obj, key_column.name, missing)
-        if key_value is missing:
-            raise MissingKey("{!r} is missing {}: {!r}".format(
-                obj, "hash_key" if key_column.hash_key else "range_key",
-                key_column.name
-            ))
-        key_value = engine._dump(key_column.typedef, key_value)
-        key[key_column.dynamo_name] = key_value
-    return key
 
 
 def validate_not_abstract(*objs):

--- a/bloop/engine.py
+++ b/bloop/engine.py
@@ -232,7 +232,7 @@ class Engine:
             for index in object_index.values():
                 for index_set in index.values():
                     not_loaded.update(index_set)
-            logger.warning("loaded {} of {} objects".format(len(objs) - len(not_loaded), len(objs)))
+            logger.info("loaded {} of {} objects".format(len(objs) - len(not_loaded), len(objs)))
             raise MissingObjects("Failed to load some objects.", objects=not_loaded)
         logger.info("successfully loaded {} objects".format(len(objs)))
 

--- a/bloop/engine.py
+++ b/bloop/engine.py
@@ -6,7 +6,6 @@ from .exceptions import (
     InvalidModel,
     InvalidStream,
     InvalidTemplate,
-    MissingKey,
     MissingObjects,
     UnknownType,
 )

--- a/bloop/exceptions.py
+++ b/bloop/exceptions.py
@@ -29,7 +29,7 @@ class TransactionCanceled(BloopException):
         The API reference for `TransactionCanceledException`_
 
         .. _TransactionCanceledException: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html#API_TransactGetItems_Errors
-    """
+    """  # noqa: E501
 
 
 class TransactionTokenExpired(BloopException):

--- a/bloop/exceptions.py
+++ b/bloop/exceptions.py
@@ -30,6 +30,10 @@ class TransactionCanceled(BloopException):
     """
 
 
+class TransactionTokenExpired(BloopException):
+    """The transaction's tx_id (ClientRequestToken) was first used more than 10 minutes ago"""
+
+
 class MissingObjects(BloopException):
     """Some objects were not found."""
     def __init__(self, *args, objects=None):

--- a/bloop/exceptions.py
+++ b/bloop/exceptions.py
@@ -29,6 +29,7 @@ class TransactionCanceled(BloopException):
         https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html#
     """
 
+
 class MissingObjects(BloopException):
     """Some objects were not found."""
     def __init__(self, *args, objects=None):

--- a/bloop/exceptions.py
+++ b/bloop/exceptions.py
@@ -6,6 +6,29 @@ class ConstraintViolation(BloopException):
     """A required condition was not met."""
 
 
+class TransactionCanceled(BloopException):
+    """The transaction was canceled.
+
+    A WriteTransaction is canceled when:
+        * A condition in one of the condition expressions is not met.
+        * A table in the TransactWriteItems request is in a different account or region.
+        * More than one action in the TransactWriteItems operation targets the same item.
+        * There is insufficient provisioned capacity for the transaction to be completed.
+        * An item size becomes too large (larger than 400 KB), or a local secondary index (LSI)
+          becomes too large, or a similar validation error occurs because of changes made by the transaction.
+
+    A ReadTransaction is canceled when:
+        * There is an ongoing TransactGetItems operation that conflicts with a concurrent PutItem,
+          UpdateItem, DeleteItem or TransactWriteItems request.
+        * A table in the TransactGetItems request is in a different account or region.
+        * There is insufficient provisioned capacity for the transaction to be completed.
+        * There is a user error, such as an invalid data format.
+
+    .. seealso::
+
+        https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html#
+    """
+
 class MissingObjects(BloopException):
     """Some objects were not found."""
     def __init__(self, *args, objects=None):

--- a/bloop/exceptions.py
+++ b/bloop/exceptions.py
@@ -26,7 +26,9 @@ class TransactionCanceled(BloopException):
 
     .. seealso::
 
-        https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html#
+        The API reference for `TransactionCanceledException`_
+
+        .. _TransactionCanceledException: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html#API_TransactGetItems_Errors
     """
 
 

--- a/bloop/exceptions.py
+++ b/bloop/exceptions.py
@@ -38,6 +38,10 @@ class TransactionTokenExpired(BloopException):
 
 class MissingObjects(BloopException):
     """Some objects were not found."""
+
+    #: The objects that failed to load
+    objects: list
+
     def __init__(self, *args, objects=None):
         super().__init__(*args)
         self.objects = list(objects) if objects else []

--- a/bloop/models.py
+++ b/bloop/models.py
@@ -56,6 +56,7 @@ class IMeta:
     ttl: Optional[Dict]
     encryption: Optional[Dict]
     backups: Optional[Dict]
+    billing: Optional[Dict]
 
     model: "BaseModel"
 
@@ -197,6 +198,7 @@ class BaseModel:
         validate_ttl(meta)
         validate_encryption(meta)
         validate_backups(meta)
+        validate_billing(meta)
 
         # 3.0 Fire model_created for customizing the class after creation
         model_created.send(None, model=cls)
@@ -688,6 +690,19 @@ def validate_backups(meta):
         raise InvalidModel("Backups must specify whether it is enabled with the 'enabled' key.")
 
 
+def validate_billing(meta):
+    billing = meta.billing
+    if billing is None:
+        return
+    if not isinstance(billing, collections.abc.MutableMapping):
+        raise InvalidModel("Billing must be None or a dict.")
+    if "mode" not in billing:
+        raise InvalidModel("Billing must specify whether it is enabled with the 'enabled' key.")
+    mode = billing["mode"]
+    if mode not in {"provisioned", "on_demand"}:
+        raise InvalidModel("Billing mode must be one of 'provisioned' or 'on_demand'")
+
+
 def validate_ttl(meta):
     ttl = meta.ttl
     if ttl is None:
@@ -777,6 +792,7 @@ def initialize_meta(cls: type):
     setdefault(meta, "ttl", None)
     setdefault(meta, "encryption", None)
     setdefault(meta, "backups", None)
+    setdefault(meta, "billing", None)
 
     setdefault(meta, "hash_key", None)
     setdefault(meta, "range_key", None)

--- a/bloop/models.py
+++ b/bloop/models.py
@@ -12,7 +12,11 @@ from .signals import model_created, object_modified
 from .types import DateTime, Number, Type
 
 
-__all__ = ["BaseModel", "Column", "GlobalSecondaryIndex", "LocalSecondaryIndex"]
+__all__ = [
+    "BaseModel", "Column",
+    "Index", "GlobalSecondaryIndex", "LocalSecondaryIndex",
+    "subclassof", "unpack_from_dynamodb"
+]
 
 logger = logging.getLogger("bloop.models")
 missing = util.missing

--- a/bloop/search.py
+++ b/bloop/search.py
@@ -6,7 +6,7 @@ from .models import Column, GlobalSecondaryIndex, unpack_from_dynamodb
 from .signals import object_loaded
 
 
-__all__ = ["ScanIterator", "QueryIterator"]
+__all__ = ["ScanIterator", "Search", "QueryIterator"]
 
 
 def printable_query(query_on):

--- a/bloop/session.py
+++ b/bloop/session.py
@@ -355,7 +355,7 @@ class SessionWrapper:
         :return: Dict with "Records" list
         """
         try:
-            return self.dynamodb_client.transact_get_items(TransactionItems=items)["Responses"]
+            return self.dynamodb_client.transact_get_items(TransactItems=items)["Responses"]
         except botocore.exceptions.ClientError as error:
             if error.response["Error"]["Code"] == "TransactionCanceledException":
                 raise TransactionCanceled from error
@@ -372,7 +372,7 @@ class SessionWrapper:
         """
         try:
             self.dynamodb_client.transact_write_items(
-                TransactionItems=items,
+                TransactItems=items,
                 ClientRequestToken=client_request_token
             )
         except botocore.exceptions.ClientError as error:

--- a/bloop/session.py
+++ b/bloop/session.py
@@ -355,7 +355,7 @@ class SessionWrapper:
         :return: Dict with "Records" list
         """
         try:
-            return self.dynamodb_client.transact_get_items(TransactItems=items)["Responses"]
+            return self.dynamodb_client.transact_get_items(TransactItems=items)
         except botocore.exceptions.ClientError as error:
             if error.response["Error"]["Code"] == "TransactionCanceledException":
                 raise TransactionCanceled from error

--- a/bloop/stream/shard.py
+++ b/bloop/stream/shard.py
@@ -34,10 +34,10 @@ class Shard:
     def __init__(self, *, stream_arn, shard_id, iterator_id=None,
                  iterator_type=None, sequence_number=None, parent=None, session=None):
 
-        # Set once on creation, never changes
+        #: The stream arn is set once on creation and never changes
         self.stream_arn = stream_arn
 
-        # Set once on creation, never changes
+        #: The shard id is set once on creation and never changes
         self.shard_id = shard_id
 
         # ID of the current iterator for this shard.

--- a/bloop/transactions.py
+++ b/bloop/transactions.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Union
 
 
-__all__ = ["Transaction", "ReadTransaction", "WriteTransaction", "new_tx"]
+__all__ = ["PreparedTransaction", "ReadTransaction", "Transaction", "WriteTransaction", "new_tx"]
 
 
 class Transaction:
@@ -40,10 +40,26 @@ class PreparedTransaction:
     tx_id: str
     first_commit_at: datetime.datetime
     request: dict
+    mode: str
+
+    def __init__(self):
+        self.objs = None
+        self.invoke = None
 
     def prepare(self, engine, objs, mode) -> None:
-        pass
-        # TODO
+        self.prepare_engine(engine, mode)
+        self.objs = objs
+
+    def prepare_engine(self, engine, mode):
+        self.mode = mode
+        if mode == "r":
+            method = engine.session.transaction_read
+        elif mode == "w":
+            method = engine.session.transaction_write
+        else:
+            raise ValueError(f"unknown mode {mode}")
+        self.invoke = method
+
 
     def commit(self) -> None:
         pass

--- a/bloop/transactions.py
+++ b/bloop/transactions.py
@@ -60,7 +60,6 @@ class PreparedTransaction:
             raise ValueError(f"unknown mode {mode}")
         self.invoke = method
 
-
     def commit(self) -> None:
         pass
         # TODO

--- a/bloop/transactions.py
+++ b/bloop/transactions.py
@@ -2,7 +2,7 @@ import enum
 import logging
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any, List, NamedTuple, Optional, Union
+from typing import Any, List, NamedTuple, Optional
 
 from .conditions import render
 from .exceptions import MissingObjects, TransactionTokenExpired
@@ -17,7 +17,6 @@ __all__ = [
     "Transaction",
     "TxItem", "TxType",
     "WriteTransaction",
-    "new_tx"
 ]
 logger = logging.getLogger("bloop.transactions")
 
@@ -27,6 +26,7 @@ MAX_TOKEN_LIFETIME = timedelta(minutes=9, seconds=30)
 
 
 class TxType(enum.Enum):
+    """Enum whose value is the wire format of its name"""
     Get = "Get"
     Check = "CheckCondition"
     Delete = "Delete"
@@ -34,18 +34,37 @@ class TxType(enum.Enum):
 
     @classmethod
     def by_alias(cls, name: str) -> "TxType":
+        """get a type by the common bloop operation name: get/check/delete/save"""
         return {
             "get": TxType.Get,
             "check": TxType.Check,
             "delete": TxType.Delete,
-            "update": TxType.Update,
+            "save": TxType.Update,
         }[name]
 
 
 class TxItem(NamedTuple):
+    """
+    Includes the type, an object, and its condition/atomic settings.
+
+    The common way to construct an item is through the ``new`` method:
+
+    .. code-block:: pycon
+
+        >>> get_item = TxItem.new("get", some_obj)
+        >>> save_item = TxItem.new("save", some_obj, atomic=True)
+    """
+
+    #: How this item will be used in a transaction
     type: TxType
+
+    #: The object that will be modified, persisted, or referenced in a transaction
     obj: Any
+
+    #: An optional condition that constrains an update
     condition: Optional[Any]
+
+    #: Whether the object must be identical locally to Dynamo before the commit takes place.
     atomic: bool
 
     @classmethod
@@ -63,7 +82,32 @@ class TxItem(NamedTuple):
         return self.type not in {TxType.Check, TxType.Get}
 
 
+# hack to get around NamedTuple field docstrings renaming:
+# https://stackoverflow.com/a/39320627
+TxItem.type.__doc__ = """How this item will be used in a transaction"""
+TxItem.obj.__doc__ = """The object that will be modified, persisted, or referenced in a transaction"""
+TxItem.condition.__doc__ = """An optional condition that constrains an update"""
+TxItem.atomic.__doc__ = """Whether the object must be identical locally to Dynamo before the commit takes place."""
+
+
 class Transaction:
+    """
+    Holds a collection of transaction items to be rendered into a PreparedTransaction.
+
+    If used as a context manager, calls prepare() and commit() when the outermost context exits.
+
+    .. code-block:: pycon
+
+        >>> engine = Engine()
+        >>> tx = Transaction(engine)
+        >>> tx.mode = "w"
+        >>> p1 = tx.prepare()
+        >>> p2 = tx.prepare()  # different instances
+
+        >>> with tx:
+        ...     pass
+        >>> #  tx.prepare().commit() is called here
+    """
     mode: str
     _items: List[TxItem]
 
@@ -81,21 +125,34 @@ class Transaction:
         if exc_type:
             return
         if self._ctx_depth == 0:
-            self.commit()
-
-    def commit(self) -> "PreparedTransaction":
-        if self._ctx_depth > 0:
-            raise RuntimeError("cannot call commit within a context manager")
-        tx = self._prepare()
-        tx.commit()
-        return tx
+            self.prepare().commit()
 
     def _extend(self, items):
         if len(self._items) + len(items) > MAX_TRANSACTION_ITEMS:
             raise RuntimeError(f"transaction cannot exceed {MAX_TRANSACTION_ITEMS} items.")
         self._items += items
 
-    def _prepare(self):
+    def prepare(self):
+        """
+        Create a new PreparedTransaction that can be committed.
+
+        This is called automatically when exiting the transaction as a context:
+
+        .. code-block:: python
+
+            >>> engine = Engine()
+            >>> tx = WriteTransaction(engine)
+            >>> prepared = tx.prepare()
+            >>> prepared.commit()
+
+            # automatically calls commit when exiting
+            >>> with WriteTransaction(engine) as tx:
+            ...     # modify the transaction here
+            ...     pass
+            >>> # tx commits here
+
+        :return:
+        """
         tx = PreparedTransaction()
         tx.prepare(
             engine=self.engine,
@@ -106,6 +163,11 @@ class Transaction:
 
 
 class PreparedTransaction:
+    """
+    Transaction that can be committed once or more.
+
+    Usually created from a :class:`~bloop.transactions.Transaction` instance.
+    """
     mode: str
     items: List[TxItem]
     tx_id: str
@@ -116,6 +178,9 @@ class PreparedTransaction:
         self._request = None
 
     def prepare(self, engine, mode, items) -> None:
+        """
+        Create a unique transaction id and dumps the items into a cached request object.
+        """
         self.tx_id = str(uuid.uuid4()).replace("-", "")
         self.engine = engine
         self.mode = mode
@@ -140,6 +205,12 @@ class PreparedTransaction:
         ]
 
     def commit(self) -> None:
+        """
+        Commit the transaction with a fixed transaction id.
+
+        A read transaction can call commit() any number of times, while a write transaction can only use the
+        same tx_id for 10 minutes from the first call.
+        """
         now = datetime.now(timezone.utc)
         if self.first_commit_at is None:
             self.first_commit_at = now
@@ -153,9 +224,9 @@ class PreparedTransaction:
         else:
             raise ValueError(f"unrecognized mode {self.mode}")
 
-        self.handle_response(response)
+        self._handle_response(response)
 
-    def handle_response(self, response: dict) -> None:
+    def _handle_response(self, response: dict) -> None:
         if self.mode == "w":
             for item in self.items:
                 obj = item.obj
@@ -182,34 +253,91 @@ class PreparedTransaction:
 
 
 class ReadTransaction(Transaction):
+    """
+    Loads all items in the same transaction.  Items can be from different models and tables.
+    """
     mode = "r"
 
     def load(self, *objs) -> "ReadTransaction":
+        """
+        Add one or more objects to be loaded in this transaction.
+
+        At most 10 items can be loaded in the same transaction.  All objects will be loaded each time you
+        call commit().
+
+
+        :param objs: Objects to add to the set that are loaded in this transaction.
+        :return: this transaction for chaining
+        :raises bloop.exceptions.MissingObjects: if one or more objects aren't loaded.
+        """
         self._extend([TxItem.new("get", obj) for obj in objs])
         return self
 
 
 class WriteTransaction(Transaction):
+    """
+    Applies all updates in the same transaction.  Items can be from different models and tables.
+
+    As with an engine, you can apply conditions to each object that you save or delete, or a condition for the entire
+    transaction that won't modify the specified object:
+
+    .. code-block:: python
+
+        # condition on some_obj
+        >>> tx.save(some_obj, condition=SomeModel.name.begins_with("foo"))
+        # condition on the tx, based on the values of some_other_obj
+        >>> tx.check(some_other_obj, condition=ThatModel.capacity >= 100)
+
+    """
     mode = "w"
 
     def check(self, obj, condition) -> "WriteTransaction":
+        """
+        Add a condition which must be met for the transaction to commit.
+
+        While the condition is checked against the provided object, that object will not be modified.  It is only
+        used to provide the hash and range key to apply the condition to.
+
+        At most 10 items can be checked, saved, or deleted in the same transaction.  The same idempotency token will
+        be used for a single prepared transaction, which allows you to safely call commit on the PreparedCommit object
+        multiple times.
+
+
+        :param obj: The object to use for the transaction condition.  This object will not be modified.
+        :param condition: A condition on an object which must hold for the transaction to commit.
+        :return: this transaction for chaining
+        """
         self._extend([TxItem.new("check", obj, condition)])
         return self
 
     def save(self, *objs, condition=None, atomic=False) -> "WriteTransaction":
-        self._extend([TxItem.new("update", obj, condition, atomic) for obj in objs])
+        """
+        Add one or more objects to be saved in this transaction.
+
+        At most 10 items can be checked, saved, or deleted in the same transaction.  The same idempotency token will
+        be used for a single prepared transaction, which allows you to safely call commit on the PreparedCommit object
+        multiple times.
+
+        :param objs: Objects to add to the set that are updated in this transaction.
+        :param condition: A condition for these objects which must hold for the transaction to commit.
+        :param bool atomic: only commit the transaction if the local and DynamoDB versions of the object match.
+        :return: this transaction for chaining
+        """
+        self._extend([TxItem.new("save", obj, condition, atomic) for obj in objs])
         return self
 
     def delete(self, *objs, condition=None, atomic=False) -> "WriteTransaction":
+        """
+        Add one or more objects to be deleted in this transaction.
+
+        At most 10 items can be checked, saved, or deleted in the same transaction.  The same idempotency token will
+        be used for a single prepared transaction, which allows you to safely call commit on the PreparedCommit object
+        multiple times.
+
+        :param objs: Objects to add to the set that are deleted in this transaction.
+        :param condition: A condition for these objects which must hold for the transaction to commit.
+        :param bool atomic: only commit the transaction if the local and DynamoDB versions of the object match.
+        :return: this transaction for chaining
+        """
         self._extend([TxItem.new("delete", obj, condition, atomic) for obj in objs])
         return self
-
-
-def new_tx(engine, mode) -> Union[ReadTransaction, WriteTransaction]:
-    if mode == "r":
-        cls = ReadTransaction
-    elif mode == "w":
-        cls = WriteTransaction
-    else:
-        raise ValueError(f"unknown mode {mode}")
-    return cls(engine)

--- a/bloop/transactions.py
+++ b/bloop/transactions.py
@@ -1,0 +1,88 @@
+import datetime
+from typing import Union
+
+
+__all__ = ["Transaction", "ReadTransaction", "WriteTransaction", "new_tx"]
+
+
+class Transaction:
+    mode: str
+
+    def __init__(self, engine):
+        self.engine = engine
+        self.objs = []
+        self._ctx_depth = 0
+
+    def __enter__(self):
+        self._ctx_depth += 1
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self._ctx_depth -= 1
+        if exc_type:
+            return
+        self.commit()
+
+    def commit(self) -> "PreparedTransaction":
+        if self._ctx_depth > 0:
+            raise ValueError("cannot call commit within a context manager")
+        tx = PreparedTransaction()
+        tx.prepare(
+            engine=self.engine,
+            objs=self.objs,
+            mode=self.mode
+        )
+        tx.commit()
+        return tx
+
+
+class PreparedTransaction:
+    tx_id: str
+    first_commit_at: datetime.datetime
+    request: dict
+
+    def prepare(self, engine, objs, mode) -> None:
+        pass
+        # TODO
+
+    def commit(self) -> None:
+        pass
+        # TODO
+
+    def _handle_response(self, resp: dict) -> None:
+        pass
+        # TODO
+
+
+class ReadTransaction(Transaction):
+    mode = "r"
+
+    def load(self, *objs) -> "ReadTransaction":
+        # TODO
+        return self
+
+
+class WriteTransaction(Transaction):
+    mode = "w"
+
+    def check(self, obj, condition) -> "WriteTransaction":
+        # TODO
+        return self
+
+    def save(self, *objs, condition=None, atomic=False) -> "WriteTransaction":
+        # TODO
+        return self
+
+    def delete(self, *objs, condition=None, atomic=False) -> "WriteTransaction":
+        # TODO
+        return self
+
+
+def new_tx(engine, mode) -> Union[ReadTransaction, WriteTransaction]:
+    if mode == "r":
+        cls = ReadTransaction
+    elif mode == "w":
+        cls = WriteTransaction
+    else:
+        raise ValueError(f"unknown mode {mode}")
+    return cls(engine)

--- a/bloop/transactions.py
+++ b/bloop/transactions.py
@@ -170,7 +170,13 @@ class PreparedTransaction:
     """
     mode: str
     items: List[TxItem]
+
+    #: Unique id used as the "ClientRequestToken" for write transactions.  This is
+    #: generated but not sent with a read transaction, since reads are not idempotent.
     tx_id: str
+
+    #: When the transaction was first committed at.  A prepared write transaction can only call commit
+    #: again within 10 minutes of its first commit.  This is ``None`` until commit() is called at least once.
     first_commit_at: Optional[datetime] = None
 
     def __init__(self):

--- a/bloop/transactions.py
+++ b/bloop/transactions.py
@@ -152,6 +152,8 @@ class PreparedTransaction:
         self.handle_response(response)
 
     def handle_response(self, response: dict) -> None:
+        if self.mode == "w":
+            return
         # TODO
         pass
 

--- a/bloop/transactions.py
+++ b/bloop/transactions.py
@@ -106,26 +106,26 @@ class WriteTransaction(Transaction):
     mode = "w"
 
     def check(self, obj, condition) -> "WriteTransaction":
-        self._extend(_TxWriteItem(mode="check", obj=obj, condition=condition, atomic=False))
+        self._extend([
+            _TxWriteItem(mode="check", obj=obj, condition=condition, atomic=False)
+        ])
         return self
 
     def save(self, *objs, condition=None, atomic=False) -> "WriteTransaction":
-        items = [
+        self._extend([
             _TxWriteItem(mode="update", obj=obj, condition=condition, atomic=atomic)
             for obj in objs
-        ]
-        self._extend(items)
+        ])
         return self
 
     def delete(self, *objs, condition=None, atomic=False) -> "WriteTransaction":
-        items = [
+        self._extend([
             _TxWriteItem(mode="delete", obj=obj, condition=condition, atomic=atomic)
             for obj in objs
-        ]
-        self._extend(items)
+        ])
         return self
 
-    def _extend(self, *items):
+    def _extend(self, items):
         if len(self.objs) + len(items) > MAX_TRANSACTION_ITEMS:
             raise ValueError(f"transaction cannot exceed {MAX_TRANSACTION_ITEMS} items.")
         self.objs += items

--- a/bloop/transactions.py
+++ b/bloop/transactions.py
@@ -97,8 +97,8 @@ class PreparedTransaction:
         self._request = [
             {
                 item.type.value: {
-                    "Key": dump_key(self.engine, item),
-                    "TableName": get_table_name(self.engine, item),
+                    "Key": dump_key(self.engine, item.obj),
+                    "TableName": get_table_name(self.engine, item.obj),
                     **render(
                         self.engine,
                         obj=item.obj if item.should_render_obj else None,

--- a/bloop/types.py
+++ b/bloop/types.py
@@ -641,7 +641,7 @@ class DynamicType(Type):
 
             4 -> 'N'
             ['x', 3] -> 'L'
-            {2, 4} -> 'SS
+            {2, 4} -> 'SS'
         """
         if isinstance(value, str):
             vtype = "S"

--- a/bloop/util.py
+++ b/bloop/util.py
@@ -100,7 +100,12 @@ def value_of(column):
 
 
 def index_for(key):
-    """index_for({'id': {'S': 'foo'}, 'range': {'S': 'bar'}}) -> ('bar', 'foo')"""
+    """stable hashable tuple of object keys for indexing an item in constant time.
+
+    usage::
+
+        index_for({'id': {'S': 'foo'}, 'range': {'S': 'bar'}}) -> ('bar', 'foo')
+    """
     return tuple(sorted(value_of(k) for k in key.values()))
 
 

--- a/bloop/util.py
+++ b/bloop/util.py
@@ -110,7 +110,15 @@ def index_for(key):
 
 
 def extract_key(key_shape, item):
-    """construct a key according to key_shape for building an index"""
+    """
+    construct a key according to key_shape for building an index
+
+    usage::
+
+        key_shape = "foo", "bar"
+        item = {"baz": 1, "bar": 2, "foo": 3}
+        extract_key(key_shape, item) -> {"foo": 3, "bar": 2}
+    """
     return {field: item[field] for field in key_shape}
 
 

--- a/bloop/util.py
+++ b/bloop/util.py
@@ -4,7 +4,7 @@ import weakref
 import blinker
 
 
-__all__ = ["Sentinel", "ordered", "signal", "walk_subclasses"]
+__all__ = ["Sentinel", "WeakDefaultDictionary", "missing", "ordered", "signal", "walk_subclasses"]
 
 # De-dupe dict for Sentinel
 _symbols = {}

--- a/bloop/util.py
+++ b/bloop/util.py
@@ -3,8 +3,15 @@ import weakref
 
 import blinker
 
+from .exceptions import MissingKey
 
-__all__ = ["Sentinel", "WeakDefaultDictionary", "missing", "ordered", "signal", "walk_subclasses"]
+
+__all__ = [
+    "Sentinel", "WeakDefaultDictionary",
+    "dump_key", "extract_key", "get_table_name",
+    "index_for", "missing", "ordered", "signal",
+    "value_of", "walk_subclasses",
+]
 
 # De-dupe dict for Sentinel
 _symbols = {}
@@ -85,6 +92,46 @@ def walk_subclasses(root):
         visited.add(cls)
         if cls is not root:
             yield cls
+
+
+def value_of(column):
+    """value_of({'S': 'Space Invaders'}) -> 'Space Invaders'"""
+    return next(iter(column.values()))
+
+
+def index_for(key):
+    """index_for({'id': {'S': 'foo'}, 'range': {'S': 'bar'}}) -> ('bar', 'foo')"""
+    return tuple(sorted(value_of(k) for k in key.values()))
+
+
+def extract_key(key_shape, item):
+    """construct a key according to key_shape for building an index"""
+    return {field: item[field] for field in key_shape}
+
+
+def dump_key(engine, obj):
+    """dump the hash (and range, if there is one) key(s) of an object into
+    a dynamo-friendly format.
+
+    returns {dynamo_name: {type: value} for dynamo_name in hash/range keys}
+    """
+    key = {}
+    for key_column in obj.Meta.keys:
+        key_value = getattr(obj, key_column.name, missing)
+        if key_value is missing:
+            raise MissingKey("{!r} is missing {}: {!r}".format(
+                obj, "hash_key" if key_column.hash_key else "range_key",
+                key_column.name
+            ))
+        # noinspection PyProtectedMember
+        key_value = engine._dump(key_column.typedef, key_value)
+        key[key_column.dynamo_name] = key_value
+    return key
+
+
+def get_table_name(engine, obj):
+    """return the table name for an object as seen by a given engine"""
+    return engine._compute_table_name(obj.__class__)
 
 
 class Sentinel:

--- a/bloop/util.py
+++ b/bloop/util.py
@@ -131,6 +131,7 @@ def dump_key(engine, obj):
 
 def get_table_name(engine, obj):
     """return the table name for an object as seen by a given engine"""
+    # noinspection PyProtectedMember
     return engine._compute_table_name(obj.__class__)
 
 

--- a/docs/api/internal.rst
+++ b/docs/api/internal.rst
@@ -190,6 +190,22 @@ atomic tracking via weakrefs) and specific parameters and error handling that Bl
 .. autoclass:: bloop.stream.buffer.RecordBuffer
     :members:
 
+==============
+ Transactions
+==============
+
+.. autoclass:: bloop.transactions.Transaction
+    :members:
+
+.. autoclass:: bloop.transactions.PreparedTransaction
+    :members:
+
+.. autoclass:: bloop.transactions.TxItem
+    :members:
+
+.. autoclass:: bloop.transactions.TxType
+    :members:
+
 ============
  Conditions
 ============

--- a/docs/api/public.rst
+++ b/docs/api/public.rst
@@ -722,6 +722,10 @@ fail with :exc`~bloop.exceptions.ConstraintViolation`.
 
 .. autoclass:: bloop.exceptions.TableMismatch
 
+.. autoclass:: bloop.exceptions.TransactionCanceled
+
+.. autoclass:: bloop.exceptions.TransactionTokenExpired
+
 -----------
  Bad Input
 -----------

--- a/docs/api/public.rst
+++ b/docs/api/public.rst
@@ -613,6 +613,18 @@ Stream.
 .. autoclass:: bloop.stream.Stream
     :members:
 
+==============
+ Transactions
+==============
+
+.. autoclass:: bloop.transactions.ReadTransaction
+    :members:
+    :inherited-members:
+
+.. autoclass:: bloop.transactions.WriteTransaction
+    :members:
+    :inherited-members:
+
 ============
  Conditions
 ============

--- a/docs/api/public.rst
+++ b/docs/api/public.rst
@@ -715,6 +715,7 @@ fail with :exc`~bloop.exceptions.ConstraintViolation`.
 .. autoclass:: bloop.exceptions.ConstraintViolation
 
 .. autoclass:: bloop.exceptions.MissingObjects
+    :members:
 
 .. autoclass:: bloop.exceptions.RecordsExpired
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,25 +8,28 @@ Requires Python 3.6+
 
 __ https://gist.github.com/numberoverzero/9584cfc375de0e087c8e1ae35ab8559c
 
-========
-Features
-========
+==========
+ Features
+==========
 
 * Simple declarative modeling
 * Stream interface that makes sense
+* Easy transactions
 * Extensible type system, useful built-in types
 * Secure expression-based wire format
 * Simple atomic operations
 * Expressive conditions
 * Model composition
 * Diff-based saves
-* Server-Side-Encryption
+* Server-Side Encryption
 * Time-To-Live
 * Continuous Backups
 
-==========
-Ergonomics
-==========
+============
+ Ergonomics
+============
+
+The basics:
 
 .. code-block:: python
 
@@ -39,45 +42,39 @@ Ergonomics
 
     engine.bind(Account)
 
-    some_account = Account(
-        id=uuid.uuid4(),
-        email='foo@bar.com')
+    some_account = Account(id=uuid.uuid4(), email='foo@bar.com')
     engine.save(some_account)
 
-    q = engine.query(
-        Account.by_email,
-        key=Account.email == 'foo@bar.com')
-
+    q = engine.query(Account.by_email, key=Account.email == 'foo@bar.com')
     same_account = q.one()
+
     print(same_account.id)
 
-Never worry about `iterator types`__, or `tracking shard lineage`__ again:
+Iterate over a stream:
 
 .. code-block:: python
 
-    template = '''
-    Old: {old}
-    New: {new}
-
-    Event Details:
-    {meta}
-
-    '''
+    template = "old: {old}\nnew: {new}\ndetails:{meta}"
 
     stream = engine.stream(User, 'trim_horizon')
     while True:
         record = next(stream)
-        if record:
-            print(template.format(**record)
-        else:
+        if not record:
             time.sleep(0.5)
+            continue
+        print(template.format(**record))
 
-__ https://docs.aws.amazon.com/dynamodbstreams/latest/APIReference/API_GetShardIterator.html#DDB-GetShardIterator-request-ShardIteratorType
-__ https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html#Streams.Processing
+Use transactions:
 
-===========
-What's Next
-===========
+.. code-block:: python
+
+    with engine.transaction() as tx:
+        tx.save(account, atomic=True)
+        tx.delete(update_token, condition=Token.until <= now())
+
+=============
+ What's Next
+=============
 
 Get started by :ref:`installing <user-install>` Bloop, or check out a :ref:`larger example <user-quickstart>`.
 
@@ -90,6 +87,7 @@ Get started by :ref:`installing <user-install>` Bloop, or check out a :ref:`larg
     user/quickstart
     user/models
     user/engine
+    user/transactions
     user/streams
     user/types
     user/conditions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ __ https://gist.github.com/numberoverzero/9584cfc375de0e087c8e1ae35ab8559c
 * Server-Side Encryption
 * Time-To-Live
 * Continuous Backups
+* On-Demand Billing
 
 ============
  Ergonomics

--- a/docs/user/engine.rst
+++ b/docs/user/engine.rst
@@ -561,6 +561,43 @@ You can easily construct a parallel scan with ``s`` segments by calling engine.s
 
 __ http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#QueryAndScanParallelScan
 
+==============
+ Transactions
+==============
+
+.. note::
+
+    For a detailed guide to using transactions, see the :ref:`user-transactions` section of the User Guide.
+
+You can construct a read or write transaction by passing each mode:
+
+.. code-block:: pycon
+
+    >>> read_tx = engine.transaction(mode="r")
+    >>> write_tx = engine.transaction(mode="w")  # defaults to write
+
+You can also use the transaction as a context manager:
+
+.. code-block:: pycon
+
+    >>> with engine.transaction() as tx:
+    ...     tx.save(user, condition=User.id.is_(None))
+    ...     tx.delete(tweet, atomic=True)
+    ...     tx.check(meta, Metadata.verified.is_(True))
+    ...
+    >>> # tx is committed or raises TransactionCanceled
+
+To manually commit a transaction, call :func:`prepare() <bloop.transactions.Transaction.prepare>` and
+:func:`commit() <bloop.transactions.PreparedTransaction.commit>`:
+
+.. code-block:: pycon
+
+    >>> tx = engine.transaction(mode="r")
+    >>> tx.load(user, tweet)
+    >>> prepared = tx.prepare()
+    >>> prepared.commit()
+    >>> prepared.commit()  # subsequent commits on a ReadTransaction re-load the objects
+
 ========
  Stream
 ========

--- a/docs/user/engine.rst
+++ b/docs/user/engine.rst
@@ -208,6 +208,8 @@ the ``atomic`` shorthand and its limitations.
 
 .. _DeleteItem: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteItem.html
 
+.. _user-engine-load:
+
 ======
  Load
 ======
@@ -242,7 +244,7 @@ If any objects aren't loaded, Bloop raises :exc:`~bloop.exceptions.MissingObject
       ...
     MissingObjects: Failed to load some objects.
 
-You can access :data:`MissingObjects.objects <bloop.exceptions.MissingObjects.objects>` to see which objects failed
+You can access :attr:`MissingObjects.objects <bloop.exceptions.MissingObjects.objects>` to see which objects failed
 to load.
 
 __ http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html

--- a/docs/user/extensions.rst
+++ b/docs/user/extensions.rst
@@ -21,7 +21,6 @@ through the :ref:`extensions module<public-ext-datetime>`.  For example, let's s
 built-in DateTime:
 
 .. code-block:: python
-    :emphasize-lines: 1, 2, 9, 10
 
     import datetime
     from bloop import DateTime
@@ -34,15 +33,11 @@ built-in DateTime:
     utc = datetime.timezone.utc
     now = datetime.datetime.now(utc)
 
-    user = User
-        id=0,
-        created_on=now
-    )
+    user = User(id=0, created_on=now)
 
 Now, using pendulum:
 
 .. code-block:: python
-    :emphasize-lines: 1, 2, 9
 
     import pendulum
     from bloop.ext.pendulum import DateTime
@@ -54,15 +49,11 @@ Now, using pendulum:
 
     now = pendulum.now("utc")
 
-    user = User
-        id=0,
-        created_on=now
-    )
+    user = User(id=0, created_on=now)
 
 Now, using arrow:
 
 .. code-block:: python
-    :emphasize-lines: 1, 2, 9
 
     import arrow
     from bloop.ext.arrow import DateTime
@@ -74,10 +65,7 @@ Now, using arrow:
 
     now = arrow.now("utc")
 
-    user = User
-        id=0,
-        created_on=now
-    )
+    user = User(id=0, created_on=now)
 
 .. _arrow: http://crsmithdev.com/arrow
 .. _delorean: https://delorean.readthedocs.io/en/latest/

--- a/docs/user/models.rst
+++ b/docs/user/models.rst
@@ -189,6 +189,30 @@ are not enabled, and this is ``None``.  To enable continuous backups, use:
 
 .. _Continuous Backups: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/BackupRestore.html
 
+---------
+ billing
+---------
+
+You can use ``billing`` to enable `On-Demand Billing`_ or explicitly require provisioned throughput.  By default
+billing is None.
+
+If you do not specify the billing mode, the existing configuration in DynamoDB is used.  When
+the table does not exist and billing mode is None, the table is created using provisioned throughput.
+
+.. code-block:: python
+
+    class Meta:
+        billing = {
+            "mode": "on_demand"
+        }
+
+    class Meta:
+        billing = {
+            "mode": "provisioned"  # if not specified, provisioned billing is used for new tables
+        }
+
+.. _On-Demand Billing: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand
+
 ------------
  encryption
 ------------

--- a/docs/user/transactions.rst
+++ b/docs/user/transactions.rst
@@ -1,0 +1,4 @@
+.. _user-transactions:
+
+Transactions
+^^^^^^^^^^^^

--- a/docs/user/transactions.rst
+++ b/docs/user/transactions.rst
@@ -2,3 +2,194 @@
 
 Transactions
 ^^^^^^^^^^^^
+
+Bloop supports reading and updating items in `transactions`_ similar to the way you already
+load, save, and delete items using an engine.  A single read or write transaction can have at most 10 items.
+
+To create a new transaction, call :func:`Engine.transaction(mode="w") <bloop.engine.Engine.transaction>` and specify
+a mode:
+
+.. code-block:: python
+
+    wx = engine.transaction(mode="w")
+    rx = engine.transaction(mode="r")
+
+When used as a context manager the transaction will call
+:func:`commit() <bloop.transactions.PreparedTransaction.commit>` on exit if no exception occurs:
+
+
+.. code-block:: python
+
+    # mode defaults to "w"
+    with engine.transaction() as tx:
+        tx.save(some_obj)
+        tx.delete(other_obj)
+
+
+    # read transaction loads all objects at once
+    user = User(id="numberoverzero")
+    meta = Metadata(id=to_load.id)
+    with engine.transaction(mode="r") as tx:
+        tx.load(user, meta)
+
+You may also call :func:`prepare() <bloop.transactions.Transaction.prepare>` and
+:func:`commit() <bloop.transactions.PreparedTransaction.commit>` yourself:
+
+.. code-block:: python
+
+    import bloop
+
+    tx = engine.transaction()
+    tx.save(some_obj)
+    p = tx.prepare()
+    try:
+        p.commit()
+    except bloop.TransactionCanceled:
+        print("failed to commit")
+
+
+See :exc:`~bloop.exceptions.TransactionCanceled` for the conditions that can cause each type of transaction to fail.
+
+.. _transactions: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transactions.html
+
+
+====================
+ Write Transactions
+====================
+
+A write transaction can save and delete items, and specify additional conditions on objects not being modified.
+
+As with :ref:`Engine.save <user-engine-save>` and :ref:`Engine.delete <user-engine-delete>` you can provide multiple
+objects to each :func:`WriteTransaction.save() <bloop.transactions.WriteTransaction.save>` or
+:func:`WriteTransaction.delete() <bloop.transactions.WriteTransaction.delete>` call:
+
+.. code-block:: python
+
+    with engine.transaction() as tx:
+        tx.delete(*old_tweets)
+        tx.save(new_user, new_tweet)
+
+-----------------
+ Item Conditions
+-----------------
+
+You can specify a ``condition`` with each save or delete call:
+
+.. code-block:: python
+
+    with engine.transaction() as tx:
+        tx.delete(auth_token, condition=Token.last_used <= now())
+
+Or use the ``atomic=`` kwarg to require that object's local state to match DynamoDb's at the time the transaction is
+committed.  For more information about the atomic keyword, see the :ref:`Engine.save <user-engine-save>` or
+:ref:`Atomic Conditions <user-conditions-atomic>` sections of the user guide.
+
+.. code-block:: python
+
+    with engine.transaction() as tx:
+        tx.save(new_user, new_tweet, atomic=True)
+
+
+------------------------
+ Transaction Conditions
+------------------------
+
+In addition to specifying conditions on the objects being modified, you can also specify a condition for the
+transaction on an object that won't be modified.  This can be useful if you want to check another table without
+changing its value:
+
+.. code-block:: python
+
+    user_meta = Metadata(id="numberoverzero")
+
+    with engine.transaction() as tx:
+        tx.save(new_tweet)
+        tx.check(user_meta, condition=Metadata.verified.is_(True))
+
+In the above example the transaction doesn't modify the user metadata.  If we want to modify that object we should
+instead use a condition on the object being modified:
+
+.. code-block:: python
+
+    user_meta = Metadata(id="numberoverzero")
+    engine.load(user_meta)
+    user_meta.tweets += 1
+
+    with engine.transaction() as tx:
+        tx.save(new_tweet)
+        tx.save(user_meta, condition=Metadata.tweets <= 500, atomic=True)
+
+-------------
+ Idempotency
+-------------
+
+Bloop automatically generates timestamped unique tokens (:attr:`~bloop.transactions.PreparedTransaction.tx_id` and
+:attr:`~bloop.transactions.PreparedTransaction.first_commit_at`)
+to guard against committing a write transaction twice or accidentally committing a transaction that was prepared a
+long time ago.  While these are generated for both read and write commits, only `TransactWriteItems`_ respects the
+`"ClientRequestToken"`_ stored in tx_id.
+
+When the :attr:`~bloop.transactions.PreparedTransaction.first_commit_at` value is too old,
+committing will raise :exc:`~bloop.exceptions.TransactionTokenExpired`.
+
+.. _TransactWriteItems: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html
+.. _"ClientRequestToken": https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html#DDB-TransactWriteItems-request-ClientRequestToken
+
+===================
+ Read Transactions
+===================
+
+By default :func:`engine.transaction(mode="w") <bloop.engine.Engine.transaction>` will create a
+:class:`~bloop.transactions.WriteTransaction`.  To create a :class:`~bloop.transactions.ReadTransaction` pass
+``mode="r"``:
+
+.. code-block:: python
+
+    with engine.transaction(mode="r") as rx:
+        rx.load(user, tweet)
+        rx.load(meta)
+
+All objects in the read transaction will be loaded at the same time, when
+:func:`commit() <bloop.transactions.PreparedTransaction.commit>` is called or the transaction context closes.
+
+------------------
+ Multiple Commits
+------------------
+
+Every time you call commit on the prepared transaction, the objects will be loaded again:
+
+.. code-block:: python
+
+    rx = engine.transaction(mode="r")
+    rx.load(user, tweet)
+    prepared = rx.prepare()
+
+    prepared.commit()  # first load
+    prepared.commit()  # second load
+
+-----------------
+ Missing Objects
+-----------------
+
+As with :ref:`Engine.load <user-engine-load>` if any objects in the transaction are missing when commit is called,
+bloop will raise :exc:`~bloop.exceptions.MissingObjects` with the list of objects that were not found:
+
+.. code-block:: python
+
+    import bloop
+
+    engine = bloop.Engine()
+    ...
+
+
+    def tx_load(*objs):
+        with engine.transaction(mode="r") as rx:
+            rx.load(*objs)
+
+    ...
+
+    try:
+        tx_load(user, tweet)
+    except bloop.MissingObjects as exc:
+        missing = exc.objects
+        print(f"failed to load {len(missing)} objects: {missing}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pendulum~=1.3
 pytest~=3.5
 pytz~=2017.0
 requests~=2.18
-sphinx==1.7.2
+sphinx==1.8.3
 sphinx-rtd-theme==0.3.0
 tox~=2.9
 twine~=1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 arrow~=0.10
 blinker~=1.4
-boto3~=1.8
+boto3~=1.9
 coverage~=4.0
 delorean~=0.6
 flake8~=3.5

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ for line in (HERE / "bloop" / "__init__.py").read_text().split("\n"):
 
 REQUIREMENTS = [
     "blinker==1.4",
-    "boto3~=1.8",
+    "boto3~=1.9",
 ]
 
 if __name__ == "__main__":

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -18,6 +18,7 @@ from bloop.exceptions import (
 from bloop.models import BaseModel, Column, GlobalSecondaryIndex
 from bloop.session import SessionWrapper
 from bloop.signals import object_saved
+from bloop.transactions import ReadTransaction, WriteTransaction
 from bloop.types import DateTime, Integer, String, Timestamp
 from bloop.util import ordered
 
@@ -610,6 +611,21 @@ def test_stream(engine, session):
 def test_invalid_stream(engine, session):
     with pytest.raises(InvalidStream):
         engine.stream(User, "latest")
+
+
+def test_transaction_read(engine):
+    tx = engine.transaction(mode="r")
+    assert isinstance(tx, ReadTransaction)
+
+
+def test_transaction_write(engine):
+    tx = engine.transaction(mode="w")
+    assert isinstance(tx, WriteTransaction)
+
+
+def test_transaction_unknown(engine):
+    with pytest.raises(ValueError):
+        engine.transaction(mode="unknown")
 
 
 def test_bind_non_model(engine):

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -613,14 +613,14 @@ def test_invalid_stream(engine, session):
         engine.stream(User, "latest")
 
 
-def test_transaction_read(engine):
-    tx = engine.transaction(mode="r")
-    assert isinstance(tx, ReadTransaction)
-
-
-def test_transaction_write(engine):
-    tx = engine.transaction(mode="w")
-    assert isinstance(tx, WriteTransaction)
+@pytest.mark.parametrize("mode, cls", [
+    ("r", ReadTransaction),
+    ("w", WriteTransaction),
+])
+def test_transaction_mode(mode, cls, engine):
+    tx = engine.transaction(mode=mode)
+    assert isinstance(tx, cls)
+    assert tx.mode == mode
 
 
 def test_transaction_unknown(engine):

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -103,7 +103,7 @@ def test_missing_objects(engine, session, caplog):
     assert set(excinfo.value.objects) == set(users)
 
     assert caplog.record_tuples == [
-        ("bloop.engine", logging.WARNING, "loaded 0 of 3 objects")
+        ("bloop.engine", logging.INFO, "loaded 0 of 3 objects")
     ]
 
 

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 import pytest
 from tests.helpers.models import ComplexModel, User, VectorModel
 
-from bloop.engine import Engine, dump_key
+from bloop.engine import Engine
 from bloop.exceptions import (
     InvalidModel,
     InvalidStream,
@@ -104,21 +104,6 @@ def test_missing_objects(engine, session, caplog):
     assert caplog.record_tuples == [
         ("bloop.engine", logging.WARNING, "loaded 0 of 3 objects")
     ]
-
-
-def test_dump_key(engine):
-    class HashAndRange(BaseModel):
-        foo = Column(Integer, hash_key=True)
-        bar = Column(Integer, range_key=True)
-    engine.bind(HashAndRange)
-
-    user = User(id="foo")
-    user_key = {"id": {"S": "foo"}}
-    assert dump_key(engine, user) == user_key
-
-    obj = HashAndRange(foo=4, bar=5)
-    obj_key = {"bar": {"N": "5"}, "foo": {"N": "4"}}
-    assert dump_key(engine, obj) == obj_key
 
 
 def test_load_object(engine, session):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -416,7 +416,7 @@ def test_invalid_stream(invalid_stream):
 
 @pytest.mark.parametrize("invalid_ttl", [
     False, True,
-    {}, User.age, {"ttl": User.age}, {"column": None}, {"column": []}
+    {}, object(), {"ttl": User.age}, {"column": None}, {"column": []}
 ])
 def test_invalid_ttl(invalid_ttl):
     """ttl must be a dict with 'column' a single Column object or Column name"""
@@ -475,7 +475,7 @@ def test_ttl_by_name():
     assert Model.Meta.ttl["column"] is my_column
 
 
-@pytest.mark.parametrize("invalid_encryption", [False, True, {}, User.age])
+@pytest.mark.parametrize("invalid_encryption", [False, True, {}, object()])
 def test_invalid_encryption(invalid_encryption):
     with pytest.raises(InvalidModel):
         class Model(BaseModel):
@@ -484,7 +484,7 @@ def test_invalid_encryption(invalid_encryption):
             id = Column(Integer, hash_key=True)
 
 
-@pytest.mark.parametrize("invalid_backups", [False, True, {}, User.age])
+@pytest.mark.parametrize("invalid_backups", [False, True, {}, object()])
 def test_invalid_backups(invalid_backups):
     with pytest.raises(InvalidModel):
         class Model(BaseModel):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -493,6 +493,21 @@ def test_invalid_backups(invalid_backups):
             id = Column(Integer, hash_key=True)
 
 
+@pytest.mark.parametrize("invalid_billing", [
+    "provisioned", "on_demand",  # no bare specification
+    ["provisioned"],  # must be a dict
+    {},  # missing "mode" key
+    {"mode": "unknown"},  # unsupported mode
+    object()
+])
+def test_invalid_billing(invalid_billing):
+    with pytest.raises(InvalidModel):
+        class Model(BaseModel):
+            class Meta:
+                billing = invalid_billing
+            id = Column(Integer, hash_key=True)
+
+
 @pytest.mark.parametrize("valid_stream", [
     {"include": ["new"]},
     {"include": ["old"]},
@@ -511,7 +526,8 @@ def test_valid_stream(valid_stream):
 @pytest.mark.parametrize("valid_encryption", [
     {"enabled": True},
     {"enabled": False},
-    {"enabled": True, "unused": object()}
+    {"enabled": True, "unused": object()},
+    None
 ])
 def test_valid_encryption(valid_encryption):
     class Model(BaseModel):
@@ -525,7 +541,8 @@ def test_valid_encryption(valid_encryption):
 @pytest.mark.parametrize("valid_backups", [
     {"enabled": True},
     {"enabled": False},
-    {"enabled": True, "unused": object()}
+    {"enabled": True, "unused": object()},
+    None
 ])
 def test_valid_backups(valid_backups):
     class Model(BaseModel):
@@ -534,6 +551,21 @@ def test_valid_backups(valid_backups):
 
         id = Column(Integer, hash_key=True)
     assert Model.Meta.backups is valid_backups
+
+
+@pytest.mark.parametrize("valid_billing", [
+    {"mode": "provisioned"},
+    {"mode": "on_demand"},
+    {"mode": "on_demand", "unused": object()},
+    None,
+])
+def test_valid_billing(valid_billing):
+    class Model(BaseModel):
+        class Meta:
+            billing = valid_billing
+
+        id = Column(Integer, hash_key=True)
+    assert Model.Meta.billing is valid_billing
 
 
 def test_require_hash():

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -21,7 +21,6 @@ from bloop.models import (
     GlobalSecondaryIndex,
     LocalSecondaryIndex,
 )
-# noinspection PyProtectedMember
 from bloop.session import (
     BATCH_GET_ITEM_CHUNK_SIZE,
     SessionWrapper,
@@ -35,6 +34,10 @@ from bloop.types import String, Timestamp
 from bloop.util import Sentinel, ordered
 
 from ..helpers.models import ComplexModel, SimpleModel, User
+
+
+# noinspection PyProtectedMember
+
 
 
 missing = Sentinel("missing")

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -64,6 +64,7 @@ def model():
     class MyModel(BaseModel):
         class Meta:
             backups = {"enabled": True}
+            billing = {"mode": "provisioned"}
             encryption = {"enabled": True}
             stream = {"include": {"old", "new"}}
             ttl = {"column": "expiry"}
@@ -130,6 +131,10 @@ def description_for(cls, active=None):
             "ContinuousBackupsStatus": "ENABLED"
         }
     description["LatestStreamArn"] = "not-a-real-arn"
+
+    # CreateTable::BillingMode -> DescribeTable::BillingModeSummary.BillingMode
+    description["BillingModeSummary"] = {"BillingMode": description.pop("BillingMode")}
+
     description = sanitize_table_description(description)
     # post-sanitize because it strips TableStatus
     if active is not None:
@@ -661,6 +666,23 @@ def test_enable_backups_wraps_exception(session, dynamodb):
 # VALIDATE TABLE ====================================================================================== VALIDATE TABLE
 
 
+def test_validate_table_all_meta(model, session, dynamodb, logger):
+    description = description_for(model, active=True)
+    dynamodb.describe_table.return_value = {"Table": description}
+    dynamodb.describe_time_to_live.return_value = {
+        "TimeToLiveDescription": {
+            "AttributeName": model.Meta.ttl["column"].dynamo_name,
+            "TimeToLiveStatus": "ENABLED"
+        }
+    }
+    dynamodb.describe_continuous_backups.return_value = {
+        "ContinuousBackupsDescription": {
+            "ContinuousBackupsStatus": "ENABLED"
+        }
+    }
+    session.validate_table(model.Meta.table_name, model)
+
+
 def test_validate_table_mismatch(basic_model, session, dynamodb, logger):
     description = description_for(basic_model, active=True)
     description["AttributeDefinitions"] = []
@@ -675,6 +697,8 @@ def test_validate_table_mismatch(basic_model, session, dynamodb, logger):
 
 def test_validate_table_sets_stream_arn(model, session, dynamodb, logger):
     # isolate the Meta component we're trying to observe
+    model.Meta.billing = None
+    # model.Meta.stream = None
     model.Meta.ttl = None
     model.Meta.encryption = None
     model.Meta.backups = None
@@ -690,7 +714,9 @@ def test_validate_table_sets_stream_arn(model, session, dynamodb, logger):
 
 def test_validate_table_sets_ttl(model, session, dynamodb, logger):
     # isolate the Meta component we're trying to observe
+    model.Meta.billing = None
     model.Meta.stream = None
+    # model.Meta.ttl = None
     model.Meta.encryption = None
     model.Meta.backups = None
 
@@ -705,12 +731,83 @@ def test_validate_table_sets_ttl(model, session, dynamodb, logger):
     dynamodb.describe_continuous_backups.return_value = {}
 
     session.validate_table(model.Meta.table_name, model)
-    assert model.Meta.ttl["enabled"] == "enabled"
-    logger.assert_logged("Set MyModel.Meta.ttl['enabled'] to 'enabled' from DescribeTable response")
+    assert model.Meta.ttl["enabled"] is True
+    logger.assert_logged("Set MyModel.Meta.ttl['enabled'] to 'True' from DescribeTable response")
+
+
+def test_validate_table_sets_encryption(model, session, dynamodb, logger):
+    # isolate the Meta component we're trying to observe
+    model.Meta.billing = None
+    model.Meta.stream = None
+    model.Meta.ttl = None
+    # model.Meta.encryption = None
+    model.Meta.backups = None
+
+    description = description_for(model, active=True)
+    dynamodb.describe_table.return_value = {"Table": description}
+    dynamodb.describe_time_to_live.return_value = {}
+    dynamodb.describe_continuous_backups.return_value = {}
+
+    # clear the Meta value so validate_table can set it
+    model.Meta.encryption = None
+
+    session.validate_table(model.Meta.table_name, model)
+    assert model.Meta.encryption["enabled"] is True
+    logger.assert_logged("Set MyModel.Meta.encryption['enabled'] to 'True' from DescribeTable response")
+
+
+def test_validate_table_sets_backups(model, session, dynamodb, logger):
+    # isolate the Meta component we're trying to observe
+    model.Meta.billing = None
+    model.Meta.stream = None
+    model.Meta.ttl = None
+    model.Meta.encryption = None
+    # model.Meta.backups = None
+
+    description = description_for(model, active=True)
+    dynamodb.describe_table.return_value = {"Table": description}
+    dynamodb.describe_time_to_live.return_value = {}
+    dynamodb.describe_continuous_backups.return_value = {
+        "ContinuousBackupsDescription": {
+            "ContinuousBackupsStatus": "ENABLED"
+        }
+    }
+
+    # clear the Meta value so validate_table can set it
+    model.Meta.backups = None
+
+    session.validate_table(model.Meta.table_name, model)
+    assert model.Meta.backups == {"enabled": True}
+    logger.assert_logged("Set MyModel.Meta.backups['enabled'] to 'True' from DescribeTable response")
+
+
+@pytest.mark.parametrize("billing_mode", ["provisioned", "on_demand"])
+def test_validate_table_sets_billing_mode(billing_mode, model, session, dynamodb, logger):
+    # isolate the Meta components we're trying to observe
+    # model.Meta.billing = None
+    model.Meta.stream = None
+    model.Meta.ttl = None
+    model.Meta.encryption = None
+    model.Meta.backups = None
+
+    model.Meta.billing["mode"] = billing_mode
+
+    description = description_for(model, active=True)
+    dynamodb.describe_table.return_value = {"Table": description}
+    dynamodb.describe_time_to_live.return_value = {}
+    dynamodb.describe_continuous_backups.return_value = {}
+
+    # clear the Meta value so validate_table can set it
+    model.Meta.billing = None
+
+    session.validate_table(model.Meta.table_name, model)
+    assert model.Meta.billing["mode"] == billing_mode
+    logger.assert_logged(f"Set MyModel.Meta.billing['mode'] to '{billing_mode}' from DescribeTable response")
 
 
 def test_validate_table_sets_table_throughput(model, session, dynamodb, logger):
     # isolate the Meta components we're trying to observe
+    model.Meta.billing = None
     model.Meta.stream = None
     model.Meta.ttl = None
     model.Meta.encryption = None
@@ -735,6 +832,7 @@ def test_validate_table_sets_table_throughput(model, session, dynamodb, logger):
 
 def test_validate_table_sets_gsi_throughput(model, session, dynamodb, logger):
     # isolate the Meta components we're trying to observe
+    model.Meta.billing = None
     model.Meta.stream = None
     model.Meta.ttl = None
     model.Meta.encryption = None
@@ -1028,21 +1126,21 @@ def test_compare_table_simple(basic_model):
     assert compare_tables(basic_model, description)
 
 
-def test_compare_table_missing_sse(model, logger):
+def test_compare_table_wrong_encryption_enabled(model, logger):
     description = description_for(model)
     description["SSEDescription"]["Status"] = "DISABLED"
     assert not compare_tables(model, description)
     logger.assert_only_logged("Model expects SSE to be 'ENABLED' but was 'DISABLED'")
 
 
-def test_compare_table_missing_backups(model, logger):
+def test_compare_table_wrong_backups_enabled(model, logger):
     description = description_for(model)
     description["ContinuousBackupsDescription"]["ContinuousBackupsStatus"] = "DISABLED"
     assert not compare_tables(model, description)
     logger.assert_only_logged("Model expects backups to be 'ENABLED' but was 'DISABLED'")
 
 
-def test_compare_table_missing_stream(model, logger):
+def test_compare_table_wrong_stream_enabled(model, logger):
     description = description_for(model)
     description["StreamSpecification"]["StreamEnabled"] = False
     assert not compare_tables(model, description)
@@ -1056,7 +1154,7 @@ def test_compare_table_wrong_stream_type(model, logger):
     logger.assert_only_logged("Model expects StreamViewType 'NEW_AND_OLD_IMAGES' but was 'UNKNOWN'")
 
 
-def test_compare_table_missing_ttl(model, logger):
+def test_compare_table_wrong_ttl_enabled(model, logger):
     description = description_for(model)
     description["TimeToLiveDescription"]["TimeToLiveStatus"] = "DISABLED"
     assert not compare_tables(model, description)
@@ -1068,6 +1166,21 @@ def test_compare_table_wrong_ttl_column(model, logger):
     description["TimeToLiveDescription"]["AttributeName"] = "wrong_column"
     assert not compare_tables(model, description)
     logger.assert_only_logged("Model expects ttl column to be 'expiry' but was 'wrong_column'")
+
+
+@pytest.mark.parametrize("expected, wire", [
+    ("on_demand", "provisioned"),
+    ("provisioned", "on_demand")
+])
+def test_compare_table_wrong_billing_mode(expected, wire, model, logger):
+    description = description_for(model)
+    description["BillingModeSummary"]["BillingMode"] = {
+        "on_demand": "PAY_PER_REQUEST",
+        "provisioned": "PROVISIONED"
+    }[wire]
+    model.Meta.billing["mode"] = expected
+    assert not compare_tables(model, description)
+    logger.assert_only_logged(f"Model expects billing mode to be '{expected}' but was '{wire}'")
 
 
 def test_compare_table_wrong_provisioned_throughput(model, logger):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -934,7 +934,7 @@ def test_get_records(dynamodbstreams, session):
 def test_transaction_read(dynamodb, session):
     response = dynamodb.transact_get_items.return_value = {"Responses": ["placeholder"]}
     result = session.transaction_read("some-items")
-    assert result is response["Responses"]
+    assert result is response
     dynamodb.transact_get_items.assert_called_once_with(TransactItems="some-items")
 
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -36,10 +36,6 @@ from bloop.util import Sentinel, ordered
 from ..helpers.models import ComplexModel, SimpleModel, User
 
 
-# noinspection PyProtectedMember
-
-
-
 missing = Sentinel("missing")
 
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -477,7 +477,9 @@ def test_create_table(session, dynamodb):
             {"AttributeType": "S", "AttributeName": "date"},
             {"AttributeType": "S", "AttributeName": "name"},
             {"AttributeType": "S", "AttributeName": "joined"},
-            {"AttributeType": "S", "AttributeName": "email"}]}
+            {"AttributeType": "S", "AttributeName": "email"}],
+        'BillingMode': 'PROVISIONED',
+    }
 
     def handle(**table):
         assert ordered(table) == ordered(expected)
@@ -496,6 +498,7 @@ def test_create_subclass(session, dynamodb):
             {'AttributeName': 'my_id', 'AttributeType': 'S'},
             {'AttributeName': 'email', 'AttributeType': 'S'},
         ],
+        'BillingMode': 'PROVISIONED',
         'KeySchema': [{'AttributeName': 'my_id', 'KeyType': 'HASH'}],
         'ProvisionedThroughput': {
             'ReadCapacityUnits': 1, 'WriteCapacityUnits': 1},
@@ -1187,6 +1190,7 @@ def test_create_simple():
     expected = {
         'AttributeDefinitions': [
             {'AttributeName': 'id', 'AttributeType': 'S'}],
+        'BillingMode': 'PROVISIONED',
         'KeySchema': [{'AttributeName': 'id', 'KeyType': 'HASH'}],
         'ProvisionedThroughput': {
             'ReadCapacityUnits': 1,
@@ -1202,6 +1206,7 @@ def test_create_complex():
             {'AttributeType': 'S', 'AttributeName': 'email'},
             {'AttributeType': 'S', 'AttributeName': 'joined'},
             {'AttributeType': 'S', 'AttributeName': 'name'}],
+        'BillingMode': 'PROVISIONED',
         'GlobalSecondaryIndexes': [{
             'IndexName': 'by_email',
             'KeySchema': [{'KeyType': 'HASH', 'AttributeName': 'email'}],

--- a/tests/unit/test_transactions.py
+++ b/tests/unit/test_transactions.py
@@ -1,12 +1,32 @@
+from unittest.mock import Mock
+
 import pytest
 
 from bloop.transactions import (
+    MAX_TRANSACTION_ITEMS,
+    PreparedTransaction,
     ReadTransaction,
+    Transaction,
     TxItem,
     TxType,
     WriteTransaction,
     new_tx,
 )
+
+
+class NoopTransaction(Transaction):
+    committed = False
+
+    def __init__(self, engine):
+        super().__init__(engine)
+        self.prepared = Mock(spec=PreparedTransaction)
+
+    def commit(self):
+        super().commit()
+        self.committed = True
+
+    def _prepare(self):
+        return self.prepared
 
 
 @pytest.mark.parametrize("type, expected", [
@@ -43,3 +63,43 @@ def test_new_tx_unknown(engine):
 def test_new_tx(mode, cls, engine):
     tx = new_tx(engine, mode)
     assert isinstance(tx, cls)
+
+
+def test_tx_nested_ctx(engine):
+    """Transaction.__exit__ should only call commit on the outer context"""
+    tx = NoopTransaction(engine)
+
+    with tx:
+        with tx:
+            with tx:
+                pass
+            assert not tx.committed
+        assert not tx.committed
+    assert tx.committed
+    tx.prepared.commit.assert_called_once()
+
+
+def test_tx_commit_in_ctx(engine):
+    """Calling transaction.commit() within a context manager raises"""
+    tx = NoopTransaction(engine)
+    # This test setup is a little weird. We want to see tx.commit raise an exception and assert that the commit
+    # didn't happen, but we *also* want to see that Transaction.__exit__ doesn't commit when an exception is
+    # bubbling up. The outer pytest.raises verified __exit__ while a manual try/except lets us assert
+    # on Transaction.commit() and re-raise so the __exit__ won't commit.
+    with pytest.raises(RuntimeError):
+        with tx:
+            try:
+                tx.commit()
+            except RuntimeError:
+                assert not tx.committed
+                raise
+        assert not tx.committed
+
+
+def test_tx_extend(engine):
+    """Each Transaction can hold transactions.MAX_TRANSACTION_ITEMS items"""
+    tx = Transaction(engine)
+    for _ in range(MAX_TRANSACTION_ITEMS):
+        tx._extend([object()])
+    with pytest.raises(RuntimeError):
+        tx._extend([object()])

--- a/tests/unit/test_transactions.py
+++ b/tests/unit/test_transactions.py
@@ -13,6 +13,8 @@ from bloop.transactions import (
     new_tx,
 )
 
+from tests.helpers.models import User
+
 
 class NoopTransaction(Transaction):
     committed = False
@@ -35,7 +37,7 @@ class NoopTransaction(Transaction):
     (TxType.Delete, False),
     (TxType.Update, True),
 ])
-def test_item_is_update(type, expected):
+def test_is_update(type, expected):
     item = TxItem(type=type, obj=None, condition=None, atomic=False)
     assert item.is_update is expected
 
@@ -46,7 +48,7 @@ def test_item_is_update(type, expected):
     (TxType.Delete, True),
     (TxType.Update, True),
 ])
-def test_item_should_render_obj(type, expected):
+def test_should_render_obj(type, expected):
     item = TxItem(type=type, obj=None, condition=None, atomic=False)
     assert item.should_render_obj is expected
 
@@ -63,9 +65,10 @@ def test_new_tx_unknown(engine):
 def test_new_tx(mode, cls, engine):
     tx = new_tx(engine, mode)
     assert isinstance(tx, cls)
+    assert tx.mode == mode
 
 
-def test_tx_nested_ctx(engine):
+def test_nested_ctx(engine):
     """Transaction.__exit__ should only call commit on the outer context"""
     tx = NoopTransaction(engine)
 
@@ -79,7 +82,7 @@ def test_tx_nested_ctx(engine):
     tx.prepared.commit.assert_called_once()
 
 
-def test_tx_commit_in_ctx(engine):
+def test_commit_in_ctx(engine):
     """Calling transaction.commit() within a context manager raises"""
     tx = NoopTransaction(engine)
     # This test setup is a little weird. We want to see tx.commit raise an exception and assert that the commit
@@ -96,10 +99,96 @@ def test_tx_commit_in_ctx(engine):
         assert not tx.committed
 
 
-def test_tx_extend(engine):
+def test_extend(engine):
     """Each Transaction can hold transactions.MAX_TRANSACTION_ITEMS items"""
     tx = Transaction(engine)
     for _ in range(MAX_TRANSACTION_ITEMS):
         tx._extend([object()])
     with pytest.raises(RuntimeError):
         tx._extend([object()])
+
+
+def test_read_item(engine):
+    engine.bind(User)
+    user = User(id="numberoverzero")
+    tx = ReadTransaction(engine)
+
+    tx.load(user)
+    p = tx._prepare()
+
+    expected_items = [TxItem.new("get", user, None, False)]
+    assert tx._items == expected_items
+    assert p.items == expected_items
+    assert p.first_commit_at is None
+
+
+def test_check_complex_item(engine):
+    engine.bind(User)
+    user = User(id="numberoverzero")
+    tx = WriteTransaction(engine)
+
+    condition = User.id.begins_with("foo")
+    tx.check(user, condition=condition)
+    p = tx._prepare()
+
+    expected_items = [TxItem.new("check", user, condition, False)]
+    assert tx._items == expected_items
+    assert p.items == expected_items
+    assert p.first_commit_at is None
+    assert len(p._request) == 1
+    entry = p._request[0]["CheckCondition"]
+    expected_fields = {
+        "Key", "TableName",
+        "ConditionExpression",
+        "ExpressionAttributeNames",
+        "ExpressionAttributeValues"
+    }
+    assert set(entry.keys()) == expected_fields
+
+
+def test_save_complex_item(engine):
+    engine.bind(User)
+    user = User(id="numberoverzero")
+    tx = WriteTransaction(engine)
+
+    condition = User.id.begins_with("foo")
+    tx.save(user, condition=condition, atomic=True)
+    p = tx._prepare()
+
+    expected_items = [TxItem.new("update", user, condition, True)]
+    assert tx._items == expected_items
+    assert p.items == expected_items
+    assert p.first_commit_at is None
+    assert len(p._request) == 1
+    entry = p._request[0]["Update"]
+    expected_fields = {
+        "Key", "TableName",
+        "ConditionExpression",
+        "ExpressionAttributeNames",
+        "ExpressionAttributeValues"
+    }
+    assert set(entry.keys()) == expected_fields
+
+
+def test_delete_complex_item(engine):
+    engine.bind(User)
+    user = User(id="numberoverzero")
+    tx = WriteTransaction(engine)
+
+    condition = User.id.begins_with("foo")
+    tx.delete(user, condition=condition, atomic=True)
+    p = tx._prepare()
+
+    expected_items = [TxItem.new("delete", user, condition, True)]
+    assert tx._items == expected_items
+    assert p.items == expected_items
+    assert p.first_commit_at is None
+    assert len(p._request) == 1
+    entry = p._request[0]["Delete"]
+    expected_fields = {
+        "Key", "TableName",
+        "ConditionExpression",
+        "ExpressionAttributeNames",
+        "ExpressionAttributeValues"
+    }
+    assert set(entry.keys()) == expected_fields

--- a/tests/unit/test_transactions.py
+++ b/tests/unit/test_transactions.py
@@ -15,22 +15,16 @@ from bloop.transactions import (
     TxItem,
     TxType,
     WriteTransaction,
-    new_tx,
 )
 
 
 class NoopTransaction(Transaction):
-    committed = False
 
     def __init__(self, engine):
         super().__init__(engine)
         self.prepared = Mock(spec=PreparedTransaction)
 
-    def commit(self):
-        super().commit()
-        self.committed = True
-
-    def _prepare(self):
+    def prepare(self):
         return self.prepared
 
 
@@ -40,7 +34,7 @@ def wx(engine):
     user = User(id="numberoverzero")
     other = User(id="other")
     items = [
-        TxItem.new("update", user, condition=User.id.is_(None)),
+        TxItem.new("save", user, condition=User.id.is_(None)),
         TxItem.new("delete", other),
         TxItem.new("check", other, condition=User.email.begins_with("foo"))
     ]
@@ -81,21 +75,6 @@ def test_should_render_obj(type, expected):
     assert item.should_render_obj is expected
 
 
-def test_new_tx_unknown(engine):
-    with pytest.raises(ValueError):
-        new_tx(engine, "unknown")
-
-
-@pytest.mark.parametrize("mode, cls", [
-    ("r", ReadTransaction),
-    ("w", WriteTransaction),
-])
-def test_new_tx(mode, cls, engine):
-    tx = new_tx(engine, mode)
-    assert isinstance(tx, cls)
-    assert tx.mode == mode
-
-
 def test_nested_ctx(engine):
     """Transaction.__exit__ should only call commit on the outer context"""
     tx = NoopTransaction(engine)
@@ -104,27 +83,16 @@ def test_nested_ctx(engine):
         with tx:
             with tx:
                 pass
-            assert not tx.committed
-        assert not tx.committed
-    assert tx.committed
     tx.prepared.commit.assert_called_once()
 
 
-def test_commit_in_ctx(engine):
-    """Calling transaction.commit() within a context manager raises"""
+def test_no_commit_during_exception(engine):
+    """Transaction.__exit__ shouldn't commit if the block raised an exception"""
     tx = NoopTransaction(engine)
-    # This test setup is a little weird. We want to see tx.commit raise an exception and assert that the commit
-    # didn't happen, but we *also* want to see that Transaction.__exit__ doesn't commit when an exception is
-    # bubbling up. The outer pytest.raises verified __exit__ while a manual try/except lets us assert
-    # on Transaction.commit() and re-raise so the __exit__ won't commit.
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ZeroDivisionError):
         with tx:
-            try:
-                tx.commit()
-            except RuntimeError:
-                assert not tx.committed
-                raise
-        assert not tx.committed
+            raise ZeroDivisionError
+    tx.prepared.commit.assert_not_called()
 
 
 def test_extend(engine):
@@ -142,7 +110,7 @@ def test_read_item(engine):
     tx = ReadTransaction(engine)
 
     tx.load(user)
-    p = tx._prepare()
+    p = tx.prepare()
 
     expected_items = [TxItem.new("get", user, None, False)]
     assert tx._items == expected_items
@@ -157,7 +125,7 @@ def test_check_complex_item(engine):
 
     condition = User.id.begins_with("foo")
     tx.check(user, condition=condition)
-    p = tx._prepare()
+    p = tx.prepare()
 
     expected_items = [TxItem.new("check", user, condition, False)]
     assert tx._items == expected_items
@@ -181,9 +149,9 @@ def test_save_complex_item(engine):
 
     condition = User.id.begins_with("foo")
     tx.save(user, condition=condition, atomic=True)
-    p = tx._prepare()
+    p = tx.prepare()
 
-    expected_items = [TxItem.new("update", user, condition, True)]
+    expected_items = [TxItem.new("save", user, condition, True)]
     assert tx._items == expected_items
     assert p.items == expected_items
     assert p.first_commit_at is None
@@ -205,7 +173,7 @@ def test_delete_complex_item(engine):
 
     condition = User.id.begins_with("foo")
     tx.delete(user, condition=condition, atomic=True)
-    p = tx._prepare()
+    p = tx.prepare()
 
     expected_items = [TxItem.new("delete", user, condition, True)]
     assert tx._items == expected_items

--- a/tests/unit/test_transactions.py
+++ b/tests/unit/test_transactions.py
@@ -1,0 +1,45 @@
+import pytest
+
+from bloop.transactions import (
+    ReadTransaction,
+    TxItem,
+    TxType,
+    WriteTransaction,
+    new_tx,
+)
+
+
+@pytest.mark.parametrize("type, expected", [
+    (TxType.Get, False),
+    (TxType.Check, False),
+    (TxType.Delete, False),
+    (TxType.Update, True),
+])
+def test_item_is_update(type, expected):
+    item = TxItem(type=type, obj=None, condition=None, atomic=False)
+    assert item.is_update is expected
+
+
+@pytest.mark.parametrize("type, expected", [
+    (TxType.Get, False),
+    (TxType.Check, False),
+    (TxType.Delete, True),
+    (TxType.Update, True),
+])
+def test_item_should_render_obj(type, expected):
+    item = TxItem(type=type, obj=None, condition=None, atomic=False)
+    assert item.should_render_obj is expected
+
+
+def test_new_tx_unknown(engine):
+    with pytest.raises(ValueError):
+        new_tx(engine, "unknown")
+
+
+@pytest.mark.parametrize("mode, cls", [
+    ("r", ReadTransaction),
+    ("w", WriteTransaction),
+])
+def test_new_tx(mode, cls, engine):
+    tx = new_tx(engine, mode)
+    assert isinstance(tx, cls)

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -69,7 +69,7 @@ def test_extract_key():
     assert extract_key(key_shape, item) == expected
 
 
-def test_get_table_name():
+def test_get_table_name(dynamodb, dynamodbstreams):
     def transform_table_name(model):
         return f"transform.{model.Meta.table_name}"
 
@@ -79,7 +79,9 @@ def test_get_table_name():
         foo = Column(Integer, hash_key=True)
         bar = Column(Integer, range_key=True)
 
-    engine = Engine(table_name_template=transform_table_name)
+    engine = Engine(
+        dynamodb=dynamodb, dynamodbstreams=dynamodbstreams,
+        table_name_template=transform_table_name)
     obj = HashAndRange()
     assert get_table_name(engine, obj) == "transform.custom.name"
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -11,7 +11,9 @@ from bloop.util import (
     WeakDefaultDictionary,
     dump_key,
     index,
+    index_for,
     ordered,
+    value_of,
     walk_subclasses,
 )
 
@@ -113,6 +115,23 @@ def test_walk_subclasses():
     # list instead of set ensures we don't false succeed on duplicates
     subclasses = sorted(walk_subclasses(A), key=lambda c: c.__name__)
     assert subclasses == [C, D, E, F]
+
+
+def test_value_of():
+    column = {"S": "Space Invaders"}
+    assert value_of(column) == "Space Invaders"
+
+
+def test_index_for_sorts():
+    key = {
+        "f": {"S": "foo"},
+        "b": {"S": "bar"},
+    }
+    same_key = {
+        "b": {"S": "bar"},
+        "f": {"S": "foo"},
+    }
+    assert index_for(key) == index_for(same_key)
 
 
 def test_sentinel_uniqueness():

--- a/tox.ini
+++ b/tox.ini
@@ -20,5 +20,5 @@ commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 
 [flake8]
-ignore = E731,W504
+ignore = E731,W504,Q000
 max-line-length = 119


### PR DESCRIPTION
2.3.0 adds support transactions and on-demand billing.  This resolves #127 and resolves #128.

Transactions can be used as a context manager, or committed manually:

```
with engine.transaction() as tx:
    tx.save(user, tweet)
    tx.delete(event, task)
    tx.check(meta, condition=Metadata.worker_id == current_worker)


tx = engine.transaction(mode="r")
tx.load(*users)
prepared = tx.prepare()
prepared.commit()  # can be called multiple times
```

On-Demand Billing is set on the Meta object; by default it is `None`.  When billing isn't specified, a new table created during `Engine.bind` will use `"provisioned"` mode.  If the table already exists, either mode will be accepted.

```
class MyModel(BaseModel):
    id = Column(String, hash_key=True)
    class Meta:
        billing = {"mode": "on_demand"}


# not specified; default value is "provisioned" on create
class MyModel(BaseModel):
    id = Column(String, hash_key=True)
```