### PR TITLE
Fixes unpacking when shard's parent is not present.

### DIFF
--- a/bloop/stream/shard.py
+++ b/bloop/stream/shard.py
@@ -323,8 +323,8 @@ def unpack_shards(shards, stream_arn, session):
              for shard_token in shards}
 
     for shard in by_id.values():
+        shard.parent = by_id.get(shard.parent)
         if shard.parent:
-            shard.parent = by_id[shard.parent]
             shard.parent.children.append(shard)
     return by_id
 


### PR DESCRIPTION
This error happens when a shard from the described stream have an already deleted parent.